### PR TITLE
Lower navigation dependency; rename package structure

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,9 +49,20 @@ dependencies {
         "androidx.appcompat:appcompat:1.6.1",
         "com.google.android.material:material:1.9.0",
         "androidx.constraintlayout:constraintlayout:2.1.4",
-        "androidx.navigation:navigation-fragment-ktx:2.7.0",
-        "androidx.navigation:navigation-ui-ktx:2.7.0",
     ).forEach(::implementation)
+
+    listOf(
+        "androidx.navigation:navigation-fragment-ktx:2.6.0",
+        "androidx.navigation:navigation-ui-ktx:2.6.0",
+    ).forEach { dep: String ->
+        implementation(dep) {
+            because(
+                "Bumping to 2.7.0 requires compile SDK 34, which the " +
+                    "Android Google Plugin (AGP) would then need to be higher than 8.1.0, which " +
+                    "is at the time of this writing, not released as a stable version yet."
+            )
+        }
+    }
 
     testImplementation("junit:junit:4.13.2")
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package com.example.onelogin
+package uk.gov.onelogin
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/main/java/uk/gov/onelogin/FirstFragment.kt
+++ b/app/src/main/java/uk/gov/onelogin/FirstFragment.kt
@@ -1,4 +1,4 @@
-package com.example.onelogin
+package uk.gov.onelogin
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
-import com.example.onelogin.databinding.FragmentFirstBinding
+import uk.gov.onelogin.databinding.FragmentFirstBinding
 
 /**
  * A simple [Fragment] subclass as the default destination in the navigation.

--- a/app/src/main/java/uk/gov/onelogin/MainActivity.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.onelogin
+package uk.gov.onelogin
 
 import android.os.Bundle
 import com.google.android.material.snackbar.Snackbar
@@ -9,7 +9,7 @@ import androidx.navigation.ui.navigateUp
 import androidx.navigation.ui.setupActionBarWithNavController
 import android.view.Menu
 import android.view.MenuItem
-import com.example.onelogin.databinding.ActivityMainBinding
+import uk.gov.onelogin.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
 

--- a/app/src/main/java/uk/gov/onelogin/SecondFragment.kt
+++ b/app/src/main/java/uk/gov/onelogin/SecondFragment.kt
@@ -1,4 +1,4 @@
-package com.example.onelogin
+package uk.gov.onelogin
 
 import android.os.Bundle
 import androidx.fragment.app.Fragment
@@ -6,7 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
-import com.example.onelogin.databinding.FragmentSecondBinding
+import uk.gov.onelogin.databinding.FragmentSecondBinding
 
 /**
  * A simple [Fragment] subclass as the second destination in the navigation.

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -1,7 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.example.onelogin.MainActivity">
+    tools:context=".MainActivity">
     <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/FirstFragment"
-        android:name="com.example.onelogin.FirstFragment"
+        android:name="uk.gov.onelogin.FirstFragment"
         android:label="@string/first_fragment_label"
         tools:layout="@layout/fragment_first">
 
@@ -17,7 +17,7 @@
     </fragment>
     <fragment
         android:id="@+id/SecondFragment"
-        android:name="com.example.onelogin.SecondFragment"
+        android:name="uk.gov.onelogin.SecondFragment"
         android:label="@string/second_fragment_label"
         tools:layout="@layout/fragment_second">
 

--- a/app/src/test/java/uk/gov/onelogin/ExampleUnitTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package com.example.onelogin
+package uk.gov.onelogin
 
 import org.junit.Test
 


### PR DESCRIPTION
- Lower version of jetpack navigation dependencies. Provide a `because`
  clause.
- Rename package structure to be prefixed with `uk.gov`.

Resolves: DCMAW-6156