### PR TITLE
Add material 2 as an implementation dep

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     listOf(
         "androidx.appcompat:appcompat:1.6.1",
         "androidx.browser:browser:1.5.0",
+        "androidx.compose.material:material:1.5.4",
         "androidx.compose.material3:material3:1.2.0-alpha08",
         "androidx.compose.ui:ui-tooling-preview:$composeVersion",
         "androidx.constraintlayout:constraintlayout:2.1.4",


### PR DESCRIPTION
Fixes the `java.lang.NoClassDefFoundError: Failed resolution of: Landroidx/compose/material/ColorsKt;` error seen in the release buildType

Resolves: DCMAW-6344