### PR TITLE
Add mobile platform team as codeowners on android one login app repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# This is the CODEOWNERS file. These owners will be the default owners for everything in the DI-MOBILE-ANDROID-ONELOGIN-APP repository
-# The following below will be requested for review when someone opens a pull request.
+# The following team(s) will be requested for review when someone opens a pull request in this repository.
 
-
-* @alphagov/di-doc-checking-shark-android
+* @govuk-one-login/mobile-platform


### PR DESCRIPTION
Aligns code ownership on this repository with documentation here https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/3791945770/Mobile+Platform+repositories+and+Github+Teams