### PR TITLE
DCMAW-7798: Implement 'passcode enabled' check

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     listOf(
         Testing.junit.jupiter,
         Testing.junit4,
+        KotlinX.coroutines.test,
         kotlin("test"),
         libs.hilt.android.testing,
         libs.ktor.client.mock,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -144,8 +144,6 @@ dependencies {
         projects.features
     ).forEach(::implementation)
 
-    implementation(libs.authentication) { isTransitive = true }
-
     listOf(
         libs.hilt.android.compiler,
         libs.hilt.compiler

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/login/WelcomeScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/login/WelcomeScreenKtTest.kt
@@ -108,12 +108,12 @@ class WelcomeScreenKtTest : TestCase() {
                 context.resources.getString(R.string.webRedirectEndpoint)
             )
         )
-        val clientId = context.resources.getString(R.string.openIdConnectClientId)
+        val clientId = context.resources.getString(R.string.stsClientId)
         val loginSessionConfig = LoginSessionConfiguration(
             authorizeEndpoint = authorizeEndpoint,
             clientId = clientId,
             redirectUri = redirectUri,
-            scopes = listOf(LoginSessionConfiguration.Scope.OPENID),
+            scopes = listOf(LoginSessionConfiguration.Scope.STS),
             tokenEndpoint = tokenEndpoint
         )
 

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -3,6 +3,7 @@
     <string name="openIdConnectBaseUrl" translatable="false">https://auth-stub.mobile.build.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.build.account.gov.uk%1$s</string>
     <string name="openIdConnectClientId" translatable="false">TEST_CLIENT_ID</string>
+    <string name="stsClientId" translatable="false">bYrcuRVvnylvEgYSSbBjwXzHrwJ</string>
     <string name="webBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.build.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>

--- a/app/src/main/java/uk/gov/onelogin/MainActivity.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivity.kt
@@ -1,6 +1,8 @@
 package uk.gov.onelogin
 
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -22,7 +24,6 @@ class MainActivity @Inject constructor() : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val context = this
         val lifecycleOwner = this
 
         installSplashScreen()
@@ -43,7 +44,7 @@ class MainActivity @Inject constructor() : AppCompatActivity() {
                         navController.navigate(it)
                     }
                     handleIntent(
-                        context = context,
+                        sharedPrefs = getTokenSharedPrefs(),
                         intent = intent
                     )
                 }
@@ -51,14 +52,21 @@ class MainActivity @Inject constructor() : AppCompatActivity() {
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
         if (requestCode == AppAuthSession.REQUEST_CODE_AUTH) {
             viewModel.handleIntent(
-                context = this,
+                sharedPrefs = getTokenSharedPrefs(),
                 intent = data
             )
         }
     }
+
+    private fun getTokenSharedPrefs(): SharedPreferences =
+        this.getSharedPreferences(
+            MainActivityViewModel.TOKENS_PREFERENCES_FILE,
+            Context.MODE_PRIVATE
+        )
 }

--- a/app/src/main/java/uk/gov/onelogin/credentialchecker/CredentialChecker.kt
+++ b/app/src/main/java/uk/gov/onelogin/credentialchecker/CredentialChecker.kt
@@ -1,0 +1,5 @@
+package uk.gov.onelogin.credentialchecker
+
+interface CredentialChecker {
+    fun isDeviceSecure(): Boolean
+}

--- a/app/src/main/java/uk/gov/onelogin/credentialchecker/CredentialCheckerModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/credentialchecker/CredentialCheckerModule.kt
@@ -1,0 +1,15 @@
+package uk.gov.onelogin.credentialchecker
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+fun interface CredentialCheckerModule {
+    @Binds
+    @ViewModelScoped
+    fun bindCredentialChecker(checker: DeviceCredentialChecker): CredentialChecker
+}

--- a/app/src/main/java/uk/gov/onelogin/credentialchecker/DeviceCredentialChecker.kt
+++ b/app/src/main/java/uk/gov/onelogin/credentialchecker/DeviceCredentialChecker.kt
@@ -1,0 +1,16 @@
+package uk.gov.onelogin.credentialchecker
+
+import android.app.KeyguardManager
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class DeviceCredentialChecker @Inject constructor(
+    @ApplicationContext
+    private val context: Context
+) : CredentialChecker {
+    override fun isDeviceSecure(): Boolean {
+        val kgm = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        return kgm.isDeviceSecure
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/login/WelcomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/WelcomeScreen.kt
@@ -56,7 +56,17 @@ fun WelcomeScreen(
                         context.resources.getString(R.string.webRedirectEndpoint)
                     )
                 )
-                val clientId = context.resources.getString(R.string.openIdConnectClientId)
+                val clientId = if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+                    context.resources.getString(R.string.stsClientId)
+                } else {
+                    context.resources.getString(R.string.openIdConnectClientId)
+                }
+
+                val scopes = if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+                    listOf(LoginSessionConfiguration.Scope.STS)
+                } else {
+                    listOf(LoginSessionConfiguration.Scope.OPENID)
+                }
 
                 loginSession
                     .present(
@@ -65,7 +75,7 @@ fun WelcomeScreen(
                             authorizeEndpoint = authorizeEndpoint,
                             clientId = clientId,
                             redirectUri = redirectUri,
-                            scopes = listOf(LoginSessionConfiguration.Scope.OPENID),
+                            scopes = scopes,
                             tokenEndpoint = tokenEndpoint
                         )
                     )

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeRoutes.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeRoutes.kt
@@ -12,6 +12,7 @@ import uk.gov.onelogin.MainActivityViewModel
 object HomeRoutes {
     const val ROOT: String = "/home"
     const val START: String = "$ROOT/start"
+    const val PASSCODE_ERROR: String = "$ROOT/passcode_error"
 
     fun NavGraphBuilder.homeFlowRoutes() {
         navigation(
@@ -37,6 +38,11 @@ object HomeRoutes {
                 HomeScreen(
                     tokens = tokens
                 )
+            }
+            composable(
+                route = PASSCODE_ERROR
+            ) {
+                PasscodeEnabledErrorScreen()
             }
         }
     }

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
@@ -87,6 +87,6 @@ fun HomeScreen(
 
 @Composable
 @Preview
-fun Preview() {
+private fun Preview() {
     HomeScreen()
 }

--- a/app/src/main/java/uk/gov/onelogin/ui/home/PasscodeEnabledErrorScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/PasscodeEnabledErrorScreen.kt
@@ -1,0 +1,41 @@
+package uk.gov.onelogin.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import uk.gov.android.ui.theme.GdsTheme
+
+@Composable
+fun PasscodeEnabledErrorScreen() {
+    GdsTheme {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text(
+                text = "Placeholder",
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun Preview() {
+    PasscodeEnabledErrorScreen()
+}

--- a/app/src/production/res/values/login_flow.xml
+++ b/app/src/production/res/values/login_flow.xml
@@ -3,6 +3,7 @@
     <string name="openIdConnectBaseUrl" translatable="false">https://oidc.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.staging.account.gov.uk%1$s</string>
     <string name="openIdConnectClientId" translatable="false">CLIENT_ID</string>
+    <string name="stsClientId" translatable="false">ctQpngJQrFFCrppZtYQFFoklHaq</string>
     <string name="webBaseUrl" translatable="false">https://mobile.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.account.gov.uk%1$s</string>

--- a/app/src/staging/res/values/login_flow.xml
+++ b/app/src/staging/res/values/login_flow.xml
@@ -3,6 +3,7 @@
     <string name="openIdConnectBaseUrl" translatable="false">https://oidc.integration.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.staging.account.gov.uk%1$s</string>
     <string name="openIdConnectClientId" translatable="false">sdJChz1oGajIz0O0tdPdh0CA2zW</string>
+    <string name="stsClientId" translatable="false">ctQpngJQrFFCrppZtYQFFoklHaq</string>
     <string name="webBaseUrl" translatable="false">https://mobile.staging.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.staging.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.staging.account.gov.uk%1$s</string>

--- a/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
@@ -1,0 +1,159 @@
+package uk.gov.onelogin
+
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.SharedPreferences.Editor
+import android.net.Uri
+import androidx.lifecycle.Observer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.LoginSession
+import uk.gov.android.authentication.TokenResponse
+import uk.gov.onelogin.credentialchecker.CredentialChecker
+import uk.gov.onelogin.extensions.InstantExecutorExtension
+import uk.gov.onelogin.login.LoginRoutes
+import uk.gov.onelogin.ui.home.HomeRoutes
+
+@ExtendWith(InstantExecutorExtension::class)
+class MainActivityViewModelTest {
+    private val mockAppRoutes: IAppRoutes = mock()
+    private val mockLoginSession: LoginSession = mock()
+    private val mockCredChecker: CredentialChecker = mock()
+    private val mockSharedPrefs: SharedPreferences = mock()
+    private val mockEditor: Editor = mock()
+
+    private val observer: Observer<String> = mock()
+
+    private val tokenResponse = TokenResponse(
+        "testType",
+        "testAccessToken",
+        1L,
+        "testIdToken",
+        "testRefreshToken",
+        "testScope"
+    )
+
+    private val viewModel = MainActivityViewModel(
+        mockAppRoutes,
+        mockLoginSession,
+        mockCredChecker
+    )
+
+    @BeforeEach
+    fun setup() {
+        whenever(mockSharedPrefs.edit()).thenReturn(mockEditor)
+        viewModel.next.observeForever(observer)
+    }
+
+    @Test
+    fun `handleIntent when data != null and device is secure`() {
+        val mockIntent: Intent = mock()
+        val mockUri: Uri = mock()
+
+        whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
+
+        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            .thenAnswer {
+                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+            }
+
+        viewModel.handleIntent(
+            mockIntent,
+            mockSharedPrefs
+        )
+
+        verify(mockEditor).putString(
+            MainActivityViewModel.TOKENS_PREFERENCES_KEY,
+            tokenResponse.jsonSerializeString()
+        )
+        verify(mockEditor).apply()
+        assertEquals(HomeRoutes.START, viewModel.next.value)
+    }
+
+    @Test
+    fun `handleIntent when data != null and device is not secure`() {
+        val mockIntent: Intent = mock()
+        val mockUri: Uri = mock()
+
+        whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockCredChecker.isDeviceSecure()).thenReturn(false)
+
+        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            .thenAnswer {
+                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+            }
+
+        viewModel.handleIntent(
+            mockIntent,
+            mockSharedPrefs
+        )
+
+        verify(mockEditor).putString(
+            MainActivityViewModel.TOKENS_PREFERENCES_KEY,
+            tokenResponse.jsonSerializeString()
+        )
+        verify(mockEditor).apply()
+        assertEquals(HomeRoutes.PASSCODE_ERROR, viewModel.next.value)
+    }
+
+    @Test
+    fun `handleIntent when data == null and tokens available`() {
+        val mockIntent: Intent = mock()
+
+        whenever(mockIntent.data).thenReturn(null)
+
+        whenever(
+            mockSharedPrefs.getString(
+                eq(MainActivityViewModel.TOKENS_PREFERENCES_KEY),
+                eq(null)
+            )
+        ).thenReturn("test")
+
+        viewModel.handleIntent(
+            mockIntent,
+            mockSharedPrefs
+        )
+
+        verify(mockEditor, times(0)).putString(
+            MainActivityViewModel.TOKENS_PREFERENCES_KEY,
+            tokenResponse.jsonSerializeString()
+        )
+        verify(mockEditor, times(0)).apply()
+        assertEquals(HomeRoutes.START, viewModel.next.value)
+    }
+
+    @Test
+    fun `handleIntent when data == null and tokens not available`() {
+        val mockIntent: Intent = mock()
+
+        whenever(mockIntent.data).thenReturn(null)
+
+        whenever(
+            mockSharedPrefs.getString(
+                eq(MainActivityViewModel.TOKENS_PREFERENCES_KEY),
+                eq(null)
+            )
+        ).thenReturn(null)
+
+        viewModel.handleIntent(
+            mockIntent,
+            mockSharedPrefs
+        )
+
+        verify(mockEditor, times(0)).putString(
+            MainActivityViewModel.TOKENS_PREFERENCES_KEY,
+            tokenResponse.jsonSerializeString()
+        )
+        verify(mockEditor, times(0)).apply()
+        assertEquals(LoginRoutes.START, viewModel.next.value)
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/extensions/InstantExecutorExtension.kt
+++ b/app/src/test/java/uk/gov/onelogin/extensions/InstantExecutorExtension.kt
@@ -1,0 +1,24 @@
+package uk.gov.onelogin.extensions
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class InstantExecutorExtension : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance()
+            .setDelegate(object : TaskExecutor() {
+                override fun executeOnDiskIO(runnable: Runnable) = runnable.run()
+
+                override fun postToMainThread(runnable: Runnable) = runnable.run()
+
+                override fun isMainThread(): Boolean = true
+            })
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/network/credentialchecker/DeviceCredentialCheckerTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/network/credentialchecker/DeviceCredentialCheckerTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.onelogin.network.credentialchecker
+
+import android.app.KeyguardManager
+import android.content.Context
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.onelogin.credentialchecker.DeviceCredentialChecker
+
+class DeviceCredentialCheckerTest {
+    private val mockContext: Context = mock()
+    private val mockKgm: KeyguardManager = mock()
+
+    private val checker = DeviceCredentialChecker(mockContext)
+
+    @Test
+    fun `check KeyguardManager result is returned`() {
+        whenever(mockContext.getSystemService(eq(Context.KEYGUARD_SERVICE)))
+            .thenReturn(mockKgm)
+        whenever(mockKgm.isDeviceSecure).thenReturn(true)
+
+        val result = checker.isDeviceSecure()
+
+        assertTrue(result)
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -76,6 +76,10 @@ version.androidx.test.espresso=3.5.1
 ##                 # available=3.6.0-alpha01
 ##                 # available=3.6.0-alpha02
 
+version.kotlinx.coroutines=1.7.3
+##             # available=1.8.0-RC
+##             # available=1.8.0-RC2
+
 ## unused
  version.ktor=2.3.6
 


### PR DESCRIPTION
### Fix for STS authorise call
- add sts client_id
- add sts scope

Resolves: DCMAW-7624

### Add Passcode Check after login
- Create `CredentialChecker` interface and `DeviceCredentialChecker` implementation to check if phone has passcode/pin
- Add placeholder error screen if device is not secure
- refactor `MainActivityViewModel` to remove need for context within

Resolves: DCMAW-7798