### PR TITLE
feat/DCMAW-7898: Save Tokens to Secure Store

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
         libs.pages,
         libs.slf4j.api,
         libs.theme,
+        libs.secure.store,
         libs.authentication,
         projects.features
     ).forEach(::implementation)

--- a/app/src/androidTest/java/uk/gov/onelogin/HomeScreenViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/HomeScreenViewModelTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.onelogin
+
+import androidx.fragment.app.FragmentActivity
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.TokenResponse
+import uk.gov.onelogin.repositiories.TokenRepository
+import uk.gov.onelogin.tokens.Keys
+import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
+import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
+
+@HiltAndroidTest
+class HomeScreenViewModelTest : TestCase() {
+    private val tokenRepository: TokenRepository = mock()
+    private val saveToSecureStore: SaveToSecureStore = mock()
+    private val saveTokenExpiry: SaveTokenExpiry = mock()
+
+    private val viewModel = HomeScreenViewModel(
+        tokenRepository,
+        saveToSecureStore,
+        saveTokenExpiry
+    )
+
+    @Test
+    fun saveTokenWhenTokensNotNull() {
+        val testResponse = TokenResponse(
+            tokenType = "test",
+            accessToken = "test",
+            accessTokenExpirationTime = 1L
+        )
+
+        whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
+
+        viewModel.saveTokens(composeTestRule.activity as FragmentActivity)
+
+        runBlocking {
+            verify(saveTokenExpiry).invoke(testResponse.accessTokenExpirationTime)
+            verify(saveToSecureStore).invoke(
+                composeTestRule.activity,
+                Keys.ACCESS_TOKENS_KEY,
+                testResponse.accessToken
+            )
+        }
+    }
+}

--- a/app/src/debug/kotlin/uk/gov/onelogin/HiltTestActivity.kt
+++ b/app/src/debug/kotlin/uk/gov/onelogin/HiltTestActivity.kt
@@ -1,7 +1,7 @@
 package uk.gov.onelogin
 
-import androidx.activity.ComponentActivity
+import androidx.fragment.app.FragmentActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class HiltTestActivity : ComponentActivity()
+class HiltTestActivity : FragmentActivity()

--- a/app/src/main/java/uk/gov/onelogin/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/HomeScreenViewModel.kt
@@ -1,0 +1,38 @@
+package uk.gov.onelogin
+
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import uk.gov.android.authentication.TokenResponse
+import uk.gov.onelogin.repositiories.TokenRepository
+import uk.gov.onelogin.tokens.Keys
+import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
+import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
+
+@HiltViewModel
+class HomeScreenViewModel @Inject constructor(
+    private val tokenRepository: TokenRepository,
+    private val saveToSecureStore: SaveToSecureStore,
+    private val saveTokenExpiry: SaveTokenExpiry
+) : ViewModel() {
+    fun saveTokens(context: FragmentActivity) {
+        val tokens = tokenRepository.getTokenResponse()
+        viewModelScope.launch {
+            tokens?.let {
+                saveTokenExpiry(it.accessTokenExpirationTime)
+                saveToSecureStore(
+                    context = context,
+                    key = Keys.ACCESS_TOKENS_KEY,
+                    value = it.accessToken
+                )
+            }
+        }
+    }
+
+    fun getTokens(): TokenResponse? {
+        return tokenRepository.getTokenResponse()
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/MainActivity.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivity.kt
@@ -1,8 +1,6 @@
 package uk.gov.onelogin
 
-import android.content.Context
 import android.content.Intent
-import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -43,7 +41,6 @@ class MainActivity : AppCompatActivity() {
                         navController.navigate(it)
                     }
                     handleIntent(
-                        sharedPrefs = getTokenSharedPrefs(),
                         intent = intent
                     )
                 }
@@ -57,15 +54,8 @@ class MainActivity : AppCompatActivity() {
 
         if (requestCode == AppAuthSession.REQUEST_CODE_AUTH) {
             viewModel.handleIntent(
-                sharedPrefs = getTokenSharedPrefs(),
                 intent = data
             )
         }
     }
-
-    private fun getTokenSharedPrefs(): SharedPreferences =
-        this.getSharedPreferences(
-            MainActivityViewModel.TOKENS_PREFERENCES_FILE,
-            Context.MODE_PRIVATE
-        )
 }

--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -66,9 +66,4 @@ class MainActivityViewModel @Inject constructor(
             _next.value = ErrorRoutes.ROOT
         }
     }
-
-    companion object {
-        const val TOKENS_PREFERENCES_FILE = "tokens"
-        const val TOKENS_PREFERENCES_KEY = "authTokens"
-    }
 }

--- a/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepository.kt
+++ b/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepository.kt
@@ -22,7 +22,7 @@ interface TokenRepository {
     fun getTokenResponse(): TokenResponse?
 }
 
-class TokenResponseImpl @Inject constructor() : TokenRepository {
+class TokenRepositoryImpl @Inject constructor() : TokenRepository {
     private var tokenResponse: TokenResponse? = null
     override fun setTokenResponse(tokens: TokenResponse) {
         tokenResponse = tokens

--- a/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepository.kt
+++ b/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepository.kt
@@ -1,0 +1,34 @@
+package uk.gov.onelogin.repositiories
+
+import javax.inject.Inject
+import uk.gov.android.authentication.TokenResponse
+
+/**
+ * Repository to hold value of tokens in working memory. [TokenResponse] held in repository has initial null value
+ */
+interface TokenRepository {
+    /**
+     * Set a value for the [TokenResponse] currently held in the repository
+     *
+     * @param tokens The [TokenResponse] to set
+     */
+    fun setTokenResponse(tokens: TokenResponse)
+
+    /**
+     * Retrieve the currently held [TokenResponse] in the repository, may be null
+     *
+     * @return [TokenResponse]
+     */
+    fun getTokenResponse(): TokenResponse?
+}
+
+class TokenResponseImpl @Inject constructor() : TokenRepository {
+    private var tokenResponse: TokenResponse? = null
+    override fun setTokenResponse(tokens: TokenResponse) {
+        tokenResponse = tokens
+    }
+
+    override fun getTokenResponse(): TokenResponse? {
+        return tokenResponse
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepositoryModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepositoryModule.kt
@@ -1,0 +1,17 @@
+package uk.gov.onelogin.repositiories
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+fun interface TokenRepositoryModule {
+    @Binds
+    @Singleton
+    fun bindTokenRepository(
+        repo: TokenResponseImpl
+    ): TokenRepository
+}

--- a/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepositoryModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/repositiories/TokenRepositoryModule.kt
@@ -12,6 +12,6 @@ fun interface TokenRepositoryModule {
     @Binds
     @Singleton
     fun bindTokenRepository(
-        repo: TokenResponseImpl
+        repo: TokenRepositoryImpl
     ): TokenRepository
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
@@ -1,0 +1,8 @@
+package uk.gov.onelogin.tokens
+
+object Keys {
+    const val SECURE_STORE_ID = "token_store"
+    const val ACCESS_TOKENS_KEY = "access_token"
+    const val TOKEN_SHARED_PREFS = "token_shared_prefs"
+    const val TOKEN_EXPIRY_KEY = "token_expiry"
+}

--- a/app/src/main/java/uk/gov/onelogin/tokens/Mapper.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/Mapper.kt
@@ -1,0 +1,18 @@
+package uk.gov.onelogin.tokens
+
+import uk.gov.android.securestore.AccessControlLevel
+import uk.gov.onelogin.login.biooptin.BiometricPreference
+
+object Mapper {
+    /**
+     * Mapper method to map [BiometricPreference] options onto [AccessControlLevel] options. Allows user choice to be used by the secure store
+     *
+     * @param bioPref [BiometricPreference] set by user
+     * @return [AccessControlLevel] that the given [BiometricPreference] maps to for use in SecureStore instance
+     */
+    fun mapAccessControlLevel(bioPref: BiometricPreference): AccessControlLevel = when (bioPref) {
+        BiometricPreference.BIOMETRICS -> AccessControlLevel.PASSCODE_AND_CURRENT_BIOMETRICS
+        BiometricPreference.PASSCODE -> AccessControlLevel.PASSCODE
+        BiometricPreference.NONE -> AccessControlLevel.OPEN
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
@@ -1,0 +1,24 @@
+package uk.gov.onelogin.tokens
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
+import uk.gov.onelogin.tokens.usecases.SaveToSecureStoreImpl
+import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
+import uk.gov.onelogin.tokens.usecases.SaveTokenExpiryImpl
+
+@Module
+@InstallIn(ViewModelComponent::class)
+interface TokenModule {
+    @Binds
+    fun bindSaveToSecureStore(
+        saveToSecureStore: SaveToSecureStoreImpl
+    ): SaveToSecureStore
+
+    @Binds
+    fun bindSaveTokenExpiry(
+        saveTokenExpiry: SaveTokenExpiryImpl
+    ): SaveTokenExpiry
+}

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToSecureStore.kt
@@ -1,0 +1,56 @@
+package uk.gov.onelogin.tokens.usecases
+
+import android.util.Log
+import androidx.fragment.app.FragmentActivity
+import javax.inject.Inject
+import uk.gov.android.securestore.SecureStorageConfiguration
+import uk.gov.android.securestore.SecureStorageError
+import uk.gov.android.securestore.SecureStore
+import uk.gov.android.securestore.SharedPrefsStore
+import uk.gov.onelogin.login.biooptin.BiometricPreference
+import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
+import uk.gov.onelogin.tokens.Keys
+import uk.gov.onelogin.tokens.Mapper
+
+fun interface SaveToSecureStore {
+    /**
+     * Use case for saving data into a secure store instance using id [Keys.SECURE_STORE_ID].
+     * The creation of the secure store handled and only created if [BiometricPreference] set
+     *
+     * @param context Must be a FragmentActivity context (due to authentication prompt)
+     * @param key [String] value of key value pair to save
+     * @param value [String] value of value in key value pair to save
+     */
+    suspend operator fun invoke(
+        context: FragmentActivity,
+        key: String,
+        value: String
+    )
+}
+
+class SaveToSecureStoreImpl @Inject constructor(
+    private val biometricPreferenceHandler: BiometricPreferenceHandler
+) : SaveToSecureStore {
+    override suspend fun invoke(context: FragmentActivity, key: String, value: String) {
+        biometricPreferenceHandler.getBioPref()?.let { bioPref ->
+            if (bioPref == BiometricPreference.NONE) return
+
+            val secureStore: SecureStore = SharedPrefsStore(
+                context,
+                configuration = SecureStorageConfiguration(
+                    Keys.SECURE_STORE_ID,
+                    Mapper.mapAccessControlLevel(bioPref)
+                )
+            )
+            try {
+                secureStore.upsert(
+                    context = context,
+                    key = key,
+                    value = value
+                )
+            } catch (e: SecureStorageError) {
+                Log.e(this::class.simpleName, e.message, e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveTokenExpiry.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveTokenExpiry.kt
@@ -1,0 +1,29 @@
+package uk.gov.onelogin.tokens.usecases
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import uk.gov.onelogin.tokens.Keys.TOKEN_EXPIRY_KEY
+import uk.gov.onelogin.tokens.Keys.TOKEN_SHARED_PREFS
+
+interface SaveTokenExpiry {
+    /**
+     * Use case to save the expiry time of the token in open shared preferences
+     *
+     * @param expiry Long type timestamp of expiry time
+     */
+    operator fun invoke(expiry: Long)
+}
+
+class SaveTokenExpiryImpl @Inject constructor(
+    @ApplicationContext
+    context: Context
+) : SaveTokenExpiry {
+    private val sharedPrefs = context.getSharedPreferences(TOKEN_SHARED_PREFS, Context.MODE_PRIVATE)
+    override fun invoke(expiry: Long) {
+        with(sharedPrefs.edit()) {
+            putLong(TOKEN_EXPIRY_KEY, expiry)
+            apply()
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeRoutes.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeRoutes.kt
@@ -1,13 +1,8 @@
 package uk.gov.onelogin.ui.home
 
-import android.content.Context
-import android.util.Log
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import uk.gov.android.authentication.TokenResponse
-import uk.gov.onelogin.MainActivityViewModel
 
 object HomeRoutes {
     const val ROOT: String = "/home"
@@ -21,22 +16,7 @@ object HomeRoutes {
             composable(
                 route = START
             ) {
-                val context = LocalContext.current
-                val tokenString = context.getSharedPreferences(
-                    MainActivityViewModel.TOKENS_PREFERENCES_FILE,
-                    Context.MODE_PRIVATE
-                ).getString(MainActivityViewModel.TOKENS_PREFERENCES_KEY, "")
-
-                var tokens: TokenResponse? = null
-                try {
-                    tokens = TokenResponse.jsonDeserialize(tokenString!!)
-                } catch (e: IllegalArgumentException) {
-                    Log.e(this.javaClass.simpleName, "Failed to deserialize tokens", e)
-                }
-
-                HomeScreen(
-                    tokens = tokens
-                )
+                HomeScreen()
             }
         }
     }

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
@@ -8,15 +8,18 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import uk.gov.android.authentication.TokenResponse
+import androidx.fragment.app.FragmentActivity
+import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.ui.components.GdsHeading
 import uk.gov.android.ui.components.HeadingParameters
 import uk.gov.android.ui.components.HeadingSize
 import uk.gov.android.ui.theme.GdsTheme
+import uk.gov.onelogin.HomeScreenViewModel
 import uk.gov.onelogin.R
 import uk.gov.onelogin.ui.components.appbar.GdsAppBar
 import uk.gov.onelogin.ui.components.navigation.GdsNavigationBar
@@ -24,8 +27,10 @@ import uk.gov.onelogin.ui.components.navigation.GdsNavigationBar
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    tokens: TokenResponse? = null
+    viewModel: HomeScreenViewModel = hiltViewModel()
 ) {
+    viewModel.saveTokens(LocalContext.current as FragmentActivity)
+    val tokens = viewModel.getTokens()
     GdsTheme {
         Column {
             /* DCMAW-7031: Configure top app bar: */

--- a/app/src/test/java/uk/gov/onelogin/extensions/CoroutinesTestExtension.kt
+++ b/app/src/test/java/uk/gov/onelogin/extensions/CoroutinesTestExtension.kt
@@ -1,0 +1,35 @@
+package uk.gov.onelogin.extensions
+
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.createTestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+@ExperimentalCoroutinesApi
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+class CoroutinesTestExtension(
+    private val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : BeforeEachCallback,
+    AfterEachCallback,
+    TestCoroutineScope by createTestCoroutineScope(
+        dispatcher
+    ) {
+
+    /**
+     * Set TestCoroutine dispatcher as main
+     */
+    override fun beforeEach(context: ExtensionContext?) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/repostiories/TokenRepositoryTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/repostiories/TokenRepositoryTest.kt
@@ -1,0 +1,35 @@
+package uk.gov.onelogin.repostiories
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import uk.gov.android.authentication.TokenResponse
+import uk.gov.onelogin.repositiories.TokenRepository
+import uk.gov.onelogin.repositiories.TokenRepositoryImpl
+
+class TokenRepositoryTest {
+    private lateinit var repo: TokenRepository
+
+    @BeforeEach
+    fun setup() {
+        repo = TokenRepositoryImpl()
+    }
+
+    @Test
+    fun `check set and retrieve`() {
+        val testResponse = TokenResponse(
+            tokenType = "test",
+            accessToken = "test",
+            accessTokenExpirationTime = 1L
+        )
+        repo.setTokenResponse(testResponse)
+
+        assertEquals(testResponse, repo.getTokenResponse())
+    }
+
+    @Test
+    fun `check null on retrieve`() {
+        assertNull(repo.getTokenResponse())
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/tokens/MapperTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/MapperTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.onelogin.tokens
+
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.android.securestore.AccessControlLevel
+import uk.gov.onelogin.login.biooptin.BiometricPreference
+import uk.gov.onelogin.tokens.Mapper.mapAccessControlLevel
+
+class MapperTest {
+    @ParameterizedTest
+    @MethodSource("args")
+    fun checkACLMappings(input: BiometricPreference, output: AccessControlLevel) {
+        val result = mapAccessControlLevel(input)
+
+        assertEquals(output, result)
+    }
+
+    companion object {
+        @JvmStatic
+        fun args(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                BiometricPreference.BIOMETRICS,
+                AccessControlLevel.PASSCODE_AND_CURRENT_BIOMETRICS
+            ),
+            Arguments.of(BiometricPreference.PASSCODE, AccessControlLevel.PASSCODE),
+            Arguments.of(BiometricPreference.NONE, AccessControlLevel.OPEN)
+        )
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/SaveTokenExpiryTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/SaveTokenExpiryTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.onelogin.tokens.usecases
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.onelogin.tokens.Keys
+
+class SaveTokenExpiryTest {
+    private lateinit var useCase: SaveTokenExpiry
+
+    private val mockContext: Context = mock()
+    private val mockSharedPreferences: SharedPreferences = mock()
+    private val mockEditor: SharedPreferences.Editor = mock()
+
+    @BeforeEach
+    fun setup() {
+        whenever(
+            mockContext.getSharedPreferences(
+                eq(Keys.TOKEN_SHARED_PREFS),
+                eq(Context.MODE_PRIVATE)
+            )
+        )
+            .thenReturn(mockSharedPreferences)
+        whenever(mockSharedPreferences.edit()).thenReturn(mockEditor)
+
+        useCase = SaveTokenExpiryImpl(mockContext)
+    }
+
+    @Test
+    fun `check expiry saved`() {
+        val expiry = 1L
+        useCase(expiry)
+
+        verify(mockEditor).putLong(Keys.TOKEN_EXPIRY_KEY, expiry)
+        verify(mockEditor).apply()
+    }
+}

--- a/config/styles/config/vocabularies/Base/accept.txt
+++ b/config/styles/config/vocabularies/Base/accept.txt
@@ -44,3 +44,4 @@ ktlint
 runBlocking
 vararg
 veriff
+bioPref

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,3 +88,4 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+secure-store = { group = "uk.gov.android", name = "securestore", version = "0.2.3" }


### PR DESCRIPTION
- Create TokenRepository to handle saving the tokens in working memory
- Create SaveToSecureStore use case to handle saving to SecureStore instance and centralise the creation of the SharedPrefsStore instance. Ensures creation only happens when a BioPref has been set
- Create SaveTokenExpiry use case to handle saving the token expiry in shared prefs
- Keys object created to house keys related to the tokens being saved in shared prefs and secure storage etc.
- Mapper method handles mapping bio prefs to access control level for secure storage
- Change in MainActivityViewModel to stop saving the tokens in shared prefs and into the new repository instead
- HomeScreen now handles saving the tokens into SecureStore via methods in HomeScreenViewModel
- Add relevant tests