### PR TITLE
feat/DCMAW-8814: Create HelloWorld sts call

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,5 +7,6 @@
   lint \
   test \
   vale \
+  detekt \
   --daemon \
   --stacktrace

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,12 +25,6 @@ android {
         targetSdk = rootProject.ext["targetSdkVersion"] as Int
         versionCode = rootProject.ext["versionCode"] as Int
         versionName = rootProject.ext["versionName"] as String
-        buildConfigField(
-            "String",
-            "KTOR_VERSION",
-            "\"${rootProject.ext.get("versionKtor") as String}\""
-        )
-
         testInstrumentationRunner = "uk.gov.onelogin.InstrumentationTestRunner"
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,11 @@ android {
         targetSdk = rootProject.ext["targetSdkVersion"] as Int
         versionCode = rootProject.ext["versionCode"] as Int
         versionName = rootProject.ext["versionName"] as String
+        buildConfigField(
+            "String",
+            "KTOR_VERSION",
+            "\"${rootProject.ext.get("versionKtor") as String}\""
+        )
 
         testInstrumentationRunner = "uk.gov.onelogin.InstrumentationTestRunner"
     }
@@ -166,8 +171,8 @@ dependencies {
         libs.slf4j.api,
         libs.theme,
         libs.secure.store,
-        libs.network,
         libs.authentication,
+        libs.network,
         projects.features
     ).forEach(::implementation)
 

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenKtTest.kt
@@ -18,7 +18,9 @@ import uk.gov.android.authentication.LoginSession
 import uk.gov.android.authentication.LoginSessionConfiguration
 import uk.gov.android.authentication.LoginSessionConfiguration.Locale
 import uk.gov.android.features.FeatureFlags
+import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.network.online.OnlineChecker
+import uk.gov.android.network.useragent.UserAgentGenerator
 import uk.gov.android.onelogin.R
 import uk.gov.onelogin.TestCase
 import uk.gov.onelogin.features.FeaturesModule
@@ -42,6 +44,12 @@ class WelcomeScreenKtTest : TestCase() {
 
     @BindValue
     val onlineChecker: OnlineChecker = mock()
+
+    @BindValue
+    val userAgentGenerator: UserAgentGenerator = mock()
+
+    @BindValue
+    val httpClient: GenericHttpClient = mock()
 
     private var navigateToOfflineErrorScreenCalled = false
     private var shouldTryAgainCalled = false
@@ -104,7 +112,7 @@ class WelcomeScreenKtTest : TestCase() {
             clientId = clientId,
             locale = Locale.EN,
             redirectUri = redirectUri,
-            scopes = listOf(LoginSessionConfiguration.Scope.OPENID),
+            scopes = listOf(LoginSessionConfiguration.Scope.STS),
             tokenEndpoint = tokenEndpoint
         )
 
@@ -127,7 +135,7 @@ class WelcomeScreenKtTest : TestCase() {
         )
         val tokenEndpoint = Uri.parse(
             context.resources.getString(
-                R.string.apiBaseUrl,
+                R.string.stsUrl,
                 context.resources.getString(R.string.tokenExchangeEndpoint)
             )
         )
@@ -143,7 +151,7 @@ class WelcomeScreenKtTest : TestCase() {
             clientId = clientId,
             locale = Locale.EN,
             redirectUri = redirectUri,
-            scopes = listOf(LoginSessionConfiguration.Scope.STS),
+            scopes = listOf(LoginSessionConfiguration.Scope.OPENID),
             tokenEndpoint = tokenEndpoint
         )
 

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -7,4 +7,5 @@
     <string name="webBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.build.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
+    <string name="helloWorldUrl" translatable="false">https://hello-world.token.build.account.gov.uk%1$s</string>
 </resources>

--- a/app/src/main/java/uk/gov/onelogin/developer/DeveloperPanelScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/DeveloperPanelScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import uk.gov.android.onelogin.R
 import uk.gov.onelogin.developer.tabs.AppTabScreen
+import uk.gov.onelogin.developer.tabs.auth.AuthTabScreen
 import uk.gov.onelogin.ui.components.SimpleTextPage
 
 @Suppress("LongMethod")
@@ -52,9 +53,7 @@ fun TabView(goBack: () -> Unit) {
             Icons.Filled.Settings
         ) { SimpleTextPage(R.string.app_developer_tab_feature_flags) },
         TabItem(R.string.app_developer_tab_auth, Icons.Filled.AccountBox) {
-            SimpleTextPage(
-                R.string.app_developer_tab_auth
-            )
+            AuthTabScreen()
         },
         TabItem(
             R.string.app_developer_tab_secure_store,

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/auth/AuthTabScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/auth/AuthTabScreen.kt
@@ -1,0 +1,102 @@
+package uk.gov.onelogin.developer.tabs.auth
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import uk.gov.android.onelogin.R
+import uk.gov.android.ui.components.m3.buttons.ButtonParameters
+import uk.gov.android.ui.components.m3.buttons.ButtonType
+import uk.gov.android.ui.components.m3.buttons.GdsButton
+
+@Composable
+fun AuthTabScreen(
+    viewModel: AuthTabScreenViewModel = hiltViewModel()
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        val happyApiResponse by viewModel.happyHelloWorldResponse
+        val happyCallLoading by viewModel.happyCallLoading
+        val sadApiResponse by viewModel.sadHelloWorldResponse
+        val sadCallLoading by viewModel.sadCallLoading
+        buttonRow(
+            buttonText = R.string.app_helloworld_happy_button,
+            buttonLoading = happyCallLoading,
+            apiResponse = happyApiResponse
+        ) {
+            viewModel.makeHappyHelloWorldCall()
+        }
+        buttonRow(
+            buttonText = R.string.app_helloworld_sad_button,
+            buttonLoading = sadCallLoading,
+            apiResponse = sadApiResponse
+        ) {
+            viewModel.makeSadHelloWorldCall()
+        }
+    }
+}
+
+@Composable
+private fun buttonRow(
+    @StringRes
+    buttonText: Int,
+    buttonLoading: Boolean,
+    apiResponse: String,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (!buttonLoading) {
+            GdsButton(
+                buttonParameters = ButtonParameters(
+                    modifier = Modifier.padding(bottom = 8.dp),
+                    text = buttonText,
+                    buttonType = ButtonType.PRIMARY(),
+                    onClick = {
+                        onClick()
+                    }
+                )
+            )
+        } else {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.secondary,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant
+            )
+        }
+        Text(
+            modifier = Modifier.padding(bottom = 8.dp),
+            text = buildAnnotatedString {
+                append("Api response: ")
+                withStyle(
+                    style = SpanStyle(
+                        fontWeight = FontWeight.Bold
+                    )
+                ) {
+                    append(apiResponse)
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/auth/AuthTabScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/auth/AuthTabScreenViewModel.kt
@@ -1,0 +1,54 @@
+package uk.gov.onelogin.developer.tabs.auth
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import uk.gov.onelogin.network.usecase.HelloWorldApiCall
+import uk.gov.onelogin.repositiories.TokenRepository
+
+@HiltViewModel
+class AuthTabScreenViewModel @Inject constructor(
+    private val helloWorldApiCall: HelloWorldApiCall,
+    private val tokenRepository: TokenRepository
+) : ViewModel() {
+    private val _happyHelloWorldResponse = mutableStateOf("")
+    val happyHelloWorldResponse: State<String>
+        get() = _happyHelloWorldResponse
+
+    private val _happyCallLoading = mutableStateOf(false)
+    val happyCallLoading: State<Boolean>
+        get() = _happyCallLoading
+
+    private val _sadHelloWorldResponse = mutableStateOf("")
+    val sadHelloWorldResponse: State<String>
+        get() = _sadHelloWorldResponse
+
+    private val _sadCallLoading = mutableStateOf(false)
+    val sadCallLoading: State<Boolean>
+        get() = _sadCallLoading
+
+    fun makeHappyHelloWorldCall() {
+        _happyCallLoading.value = true
+        viewModelScope.launch {
+            _happyHelloWorldResponse.value = helloWorldApiCall()
+            _happyCallLoading.value = false
+        }
+    }
+
+    fun makeSadHelloWorldCall() {
+        _sadCallLoading.value = true
+        viewModelScope.launch {
+            val currentToken = tokenRepository.getTokenResponse()
+            tokenRepository.clearTokenResponse()
+            _sadHelloWorldResponse.value = helloWorldApiCall()
+            _sadCallLoading.value = false
+            if (currentToken != null) {
+                tokenRepository.setTokenResponse(currentToken)
+            }
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/features/FeaturesModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/features/FeaturesModule.kt
@@ -15,5 +15,7 @@ import uk.gov.android.features.InMemoryFeatureFlags
 object FeaturesModule {
     @Provides
     @Singleton
-    fun providesFeatureFlags(): FeatureFlags = InMemoryFeatureFlags()
+    fun providesFeatureFlags(): FeatureFlags = InMemoryFeatureFlags(
+        setOf(StsFeatureFlag.STS_ENDPOINT)
+    )
 }

--- a/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
@@ -33,7 +33,11 @@ class WelcomeScreenViewModel @Inject constructor(
         )
         val tokenEndpoint = Uri.parse(
             context.resources.getString(
-                R.string.apiBaseUrl,
+                if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+                    R.string.stsUrl
+                } else {
+                    R.string.apiBaseUrl
+                },
                 context.resources.getString(R.string.tokenExchangeEndpoint)
             )
         )
@@ -50,9 +54,9 @@ class WelcomeScreenViewModel @Inject constructor(
         }
 
         val scopes = if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
-            listOf(LoginSessionConfiguration.Scope.STS)
-        } else {
             listOf(LoginSessionConfiguration.Scope.OPENID)
+        } else {
+            listOf(LoginSessionConfiguration.Scope.STS)
         }
         val locale = getLocaleFrom(context)
         loginSession

--- a/app/src/main/java/uk/gov/onelogin/network/StsAuthenticationProvider.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/StsAuthenticationProvider.kt
@@ -9,6 +9,7 @@ import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse
 import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.onelogin.network.data.TokenApiResponse
 import uk.gov.onelogin.repositiories.TokenRepository
 
 class StsAuthenticationProvider(

--- a/app/src/main/java/uk/gov/onelogin/network/data/TokenApiResponse.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/data/TokenApiResponse.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.network
+package uk.gov.onelogin.network.data
 
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable

--- a/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
@@ -69,6 +69,4 @@ object NetworkModule {
         client.setAuthenticationProvider(authProvider)
         return client
     }
-
-    private const val KTOR_CLIENT = "Ktor"
 }

--- a/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package uk.gov.onelogin.network.di
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.os.Build
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,8 +12,10 @@ import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.network.client.KtorHttpClient
 import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.network.online.OnlineCheckerImpl
+import uk.gov.android.network.useragent.UserAgent
 import uk.gov.android.network.useragent.UserAgentGenerator
 import uk.gov.android.network.useragent.UserAgentGeneratorImpl
+import uk.gov.android.onelogin.BuildConfig
 import uk.gov.android.onelogin.R
 import uk.gov.onelogin.network.StsAuthenticationProvider
 import uk.gov.onelogin.repositiories.TokenRepository
@@ -31,14 +34,33 @@ object NetworkModule {
     }
 
     @Provides
+    fun providesUserAgentGenerator(@ApplicationContext context: Context): UserAgentGenerator {
+        val userAgentGenerator = UserAgentGeneratorImpl()
+        val appName = context.resources.getString(R.string.app_name)
+        userAgentGenerator.setUserAgent(
+            UserAgent(
+                appName = appName,
+                versionName = BuildConfig.VERSION_NAME,
+                clientName = KTOR_CLIENT,
+                manufacturer = Build.MANUFACTURER,
+                model = Build.MODEL,
+                sdkVersion = Build.VERSION.SDK_INT,
+                clientVersion = BuildConfig.KTOR_VERSION
+            )
+        )
+        return userAgentGenerator
+    }
+
+    @Provides
     fun provideHttpClient(
         @ApplicationContext
         context: Context,
+        userAgentGenerator: UserAgentGenerator,
         tokenRepository: TokenRepository
     ): GenericHttpClient {
-        val userAgentGenerator: UserAgentGenerator = UserAgentGeneratorImpl()
         val client = KtorHttpClient(userAgentGenerator)
-        val url = context.getString(R.string.stsUrl)
+        val endpoint = context.getString(R.string.tokenExchangeEndpoint)
+        val url = context.getString(R.string.stsUrl, endpoint)
         val authProvider = StsAuthenticationProvider(
             url,
             tokenRepository,
@@ -47,4 +69,6 @@ object NetworkModule {
         client.setAuthenticationProvider(authProvider)
         return client
     }
+
+    private const val KTOR_CLIENT = "Ktor"
 }

--- a/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/di/NetworkModule.kt
@@ -41,11 +41,11 @@ object NetworkModule {
             UserAgent(
                 appName = appName,
                 versionName = BuildConfig.VERSION_NAME,
-                clientName = KTOR_CLIENT,
+                clientName = BuildConfig.APPLICATION_ID,
                 manufacturer = Build.MANUFACTURER,
                 model = Build.MODEL,
                 sdkVersion = Build.VERSION.SDK_INT,
-                clientVersion = BuildConfig.KTOR_VERSION
+                clientVersion = BuildConfig.VERSION_NAME
             )
         )
         return userAgentGenerator

--- a/app/src/main/java/uk/gov/onelogin/network/di/NetworkUsecaseModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/di/NetworkUsecaseModule.kt
@@ -1,0 +1,15 @@
+package uk.gov.onelogin.network.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import uk.gov.onelogin.network.usecase.HelloWorldApiCall
+import uk.gov.onelogin.network.usecase.HelloWorldApiCallImpl
+
+@Module
+@InstallIn(ViewModelComponent::class)
+fun interface NetworkUsecaseModule {
+    @Binds
+    fun bindHelloWorldApiCall(impl: HelloWorldApiCallImpl): HelloWorldApiCall
+}

--- a/app/src/main/java/uk/gov/onelogin/network/usecase/HelloWorldApiCall.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/usecase/HelloWorldApiCall.kt
@@ -1,0 +1,32 @@
+package uk.gov.onelogin.network.usecase
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import uk.gov.android.network.api.ApiRequest
+import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.onelogin.R
+
+interface HelloWorldApiCall {
+    suspend operator fun invoke(): String
+}
+
+class HelloWorldApiCallImpl @Inject constructor(
+    @ApplicationContext
+    private val context: Context,
+    private val httpClient: GenericHttpClient
+) : HelloWorldApiCall {
+    override suspend fun invoke(): String {
+        val endpoint = context.getString(R.string.helloWorldEndpoint)
+        val request = ApiRequest.Get(
+            url = context.getString(R.string.helloWorldUrl, endpoint)
+        )
+        val response = httpClient.makeAuthorisedRequest(request, "sts-test.hello-world.read")
+        return if (response is ApiResponse.Success<*>) {
+            (response as ApiResponse.Success<String>).response
+        } else {
+            (response as ApiResponse.Failure).error.message ?: "Error"
+        }
+    }
+}

--- a/app/src/main/res/values/endpoints.xml
+++ b/app/src/main/res/values/endpoints.xml
@@ -3,5 +3,6 @@
     <string name="openIdConnectAuthorizeEndpoint" translatable="false">/authorize</string>
 
     <string name="webRedirectEndpoint" translatable="false">/redirect</string>
+    <string name="helloWorldEndpoint" translatable="false">/hello-world</string>
     <string name="tokenExchangeEndpoint" translatable="false">/token</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,9 @@
     <string name="app_developer_tab_auth" translatable="false">Auth</string>
     <string name="app_developer_tab_secure_store" translatable="false">Secure Store</string>
 
+    <string name="app_helloworld_happy_button" translatable="false">Successful Hello World Call</string>
+    <string name="app_helloworld_sad_button" translatable="false">Failing Hello World Call</string>
+
     <string name="lorem_ipsum" translatable="false">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam in scelerisque sem. Mauris
         volutpat, dolor id interdum ullamcorper, risus dolor egestas lectus, sit amet mattis purus

--- a/app/src/production/res/values/login_flow.xml
+++ b/app/src/production/res/values/login_flow.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="openIdConnectBaseUrl" translatable="false">https://oidc.account.gov.uk%1$s</string>
-    <string name="stsUrl" translatable="false">https://token.staging.account.gov.uk%1$s</string>
+    <string name="stsUrl" translatable="false">https://token.account.gov.uk%1$s</string>
     <string name="openIdConnectClientId" translatable="false">CLIENT_ID</string>
     <string name="stsClientId" translatable="false">ctQpngJQrFFCrppZtYQFFoklHaq</string>
     <string name="webBaseUrl" translatable="false">https://mobile.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.account.gov.uk%1$s</string>
+    <string name="helloWorldUrl" translatable="false">https://hello-world.token.account.gov.uk%1$s</string>
 </resources>

--- a/app/src/staging/res/values/login_flow.xml
+++ b/app/src/staging/res/values/login_flow.xml
@@ -7,4 +7,5 @@
     <string name="webBaseUrl" translatable="false">https://mobile.staging.account.gov.uk%1$s</string>
     <string name="webBaseHost" translatable="false">mobile.staging.account.gov.uk</string>
     <string name="apiBaseUrl" translatable="false">https://mobile.staging.account.gov.uk%1$s</string>
+    <string name="helloWorldUrl" translatable="false">https://hello-world.token.staging.account.gov.uk%1$s</string>
 </resources>

--- a/app/src/test/java/uk/gov/onelogin/network/usecase/HelloWorldApiCallTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/network/usecase/HelloWorldApiCallTest.kt
@@ -1,0 +1,40 @@
+package uk.gov.onelogin.network.usecase
+
+import android.content.Context
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.android.network.api.ApiResponse
+import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.network.client.StubHttpClient
+import uk.gov.android.onelogin.R
+
+class HelloWorldApiCallTest {
+    private val mockContext: Context = mock()
+    private lateinit var stubHttpClient: GenericHttpClient
+    private lateinit var usecase: HelloWorldApiCall
+
+    @BeforeEach
+    fun setup() {
+        whenever(mockContext.getString(R.string.helloWorldEndpoint))
+            .thenReturn("/hello-world")
+        whenever(mockContext.getString(R.string.helloWorldUrl, "/hello-world"))
+            .thenReturn("hello-world.com")
+    }
+
+    @Test
+    fun `successful call returns hello world text`() = runTest {
+        setupUsecase(ApiResponse.Success("Hello World!"))
+        val response = usecase()
+
+        assertEquals("Hello World!", response)
+    }
+
+    private fun setupUsecase(httpResponse: ApiResponse) {
+        stubHttpClient = StubHttpClient(httpResponse)
+        usecase = HelloWorldApiCallImpl(mockContext, stubHttpClient)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ setProperty("minSdkVersion", 29)
 setProperty("targetSdkVersion", 34)
 setProperty("versionCode", getVersionCode())
 setProperty("versionName", getVersionName())
+setProperty("versionKtor", "2.3.7")
 
 fun getVersionCode(): Int {
     val code: Int =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ setProperty("minSdkVersion", 29)
 setProperty("targetSdkVersion", 34)
 setProperty("versionCode", getVersionCode())
 setProperty("versionName", getVersionName())
-setProperty("versionKtor", "2.3.7")
 
 fun getVersionCode(): Int {
     val code: Int =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,7 @@ org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version = 
 com-android-library = { id = "com.android.library", version.ref = "agp" }
 
 [versions]
-
 kotlin = "1.9.21"
-
 androidx-databinding = "8.1.3"
 agp = "8.3.1"
 core-ktx = "1.12.0"
@@ -90,5 +88,5 @@ espresso-core = { group = "androidx.test.espresso", name = "espresso-core", vers
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 secure-store = { group = "uk.gov.android", name = "securestore", version = "0.5.0" }
-network = { group = "uk.gov.android", name = "network", version = "0.2.1" }
+network = { group = "uk.gov.android", name = "network", version = "0.2.2" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }


### PR DESCRIPTION
- Creation of `AuthTabScreen` to live in the developer menu. This has two buttons to allow a happy and sad path call to `/hello-world` endpoint
- `AuthTabScreenViewModel` handles making the calls to hello world. Sad call temporarily deletes the stored access token to simulate an error
- STS endpoint feature is turned on
- Use case `HelloWorldApiCall` created to handle calls to `/hello-world` endpoint
- Necessary hilt modules created to provide http clients from the android-network module
- Slight changes in `WelcomeScreenViewModel` to fix calling the STS `/authorize` url

Resolves: DCMAW-8814