### PR TITLE
feat/DCMAW-9394: save persistent id

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ androidComponents {
 }
 
 dependencies {
+//    implementation(files("/Users/abradbury/AndroidStudioProjects/mobileandroidsecurestore/app/build/outputs/aar/app-release.aar"))
     listOf(
         libs.androidx.compose.ui.junit4,
         libs.androidx.navigation.testing,

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,7 +134,6 @@ androidComponents {
 }
 
 dependencies {
-//    implementation(files("/Users/abradbury/AndroidStudioProjects/mobileandroidsecurestore/app/build/outputs/aar/app-release.aar"))
     listOf(
         libs.androidx.compose.ui.junit4,
         libs.androidx.navigation.testing,

--- a/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
@@ -242,15 +242,14 @@ class LoginTest : TestCase() {
             tokenType = "test",
             accessToken = "test",
             accessTokenExpirationTime = 1L,
-            idToken = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3L" +
-                "TU0NDUtNDVkNi1hN2Q5LTk4NzgxZWJkZjkzZCJ9.eyJhdWQiOiJHRVV6a0V6" +
-                "SVFVOXJmYmdBWmJzal9fMUVOUU0iLCJpc3MiOiJodHRwczovL3Rva2VuLmJ" +
-                "1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiMmU5YzdlMTYtZmQ4NS00Yz" +
-                "A5LThkM2EtZDA2MzljMTUzMzc4IiwiaWF0IjoxNzE3NTc4NzY4LCJleHAiOj" +
-                "E3MTc1Nzg5NDgsIm5vbmNlIjoidGVzdF9ub25jZSIsImVtYWlsIjoibW9ja0" +
-                "BlbWFpbC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZX0.j1xQsDeX37Z8Bn" +
-                "B-Aq4ovVfGq1ADa9cycYJHtlcSfZwSh_0c_FowQPN7MJjRHBdAE1pnjqtnbi" +
-                "c14VFnJuMCoA"
+            idToken = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN" +
+                "2Q5LTk4NzgxZWJkZjkzZCJ9.eyJhdWQiOiJHRVV6a0V6SVFVOXJmYmdBWmJzal9fMUVOUU0iLCJ" +
+                "pc3MiOiJodHRwczovL3Rva2VuLmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiOWQwZjIxZG" +
+                "UtMmZkNy00MjdiLWE2ZGYtMDdjZDBkOTVlM2I2IiwicGVyc2lzdGVudF9pZCI6ImNjODkzZWNlL" +
+                "WI2YmQtNDQ0ZC05YmI0LWRlYzZmNTc3OGU1MCIsImlhdCI6MTcyMTk5ODE3OCwiZXhwIjoxNzIx" +
+                "OTk4MzU4LCJub25jZSI6InRlc3Rfbm9uY2UiLCJlbWFpbCI6Im1vY2tAZW1haWwuY29tIiwiZW1" +
+                "haWxfdmVyaWZpZWQiOnRydWV9.G1uQ9z2i-214kEmmtK7hEHRsgqJdk7AXjz_CaJDiuuqSyHZ4W" +
+                "48oE1karDBA-pKWpADdBpHeUC-eCjjfBObjOg"
         )
         whenever(mockLoginSession.finalise(any(), any())).thenAnswer {
             (it.arguments[1] as (TokenResponse) -> Unit).invoke(tokenResponse)

--- a/app/src/androidTest/java/uk/gov/onelogin/login/usecase/HandleLoginTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/usecase/HandleLoginTest.kt
@@ -16,20 +16,20 @@ import uk.gov.onelogin.login.biooptin.BiometricPreference
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.login.state.LocalAuthStatus
 import uk.gov.onelogin.repositiories.TokenRepository
-import uk.gov.onelogin.tokens.usecases.GetFromSecureStore
+import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiry
 
 @HiltAndroidTest
 class HandleLoginTest : TestCase() {
     private val mockGetTokenExpiry: GetTokenExpiry = mock()
     private val mockTokenRepository: TokenRepository = mock()
-    private val mockGetFromSecureStore: GetFromSecureStore = mock()
+    private val mockGetFromTokenSecureStore: GetFromTokenSecureStore = mock()
     private val mockBioPrefHandler: BiometricPreferenceHandler = mock()
 
     private val useCase = HandleLoginImpl(
         mockGetTokenExpiry,
         mockTokenRepository,
-        mockGetFromSecureStore,
+        mockGetFromTokenSecureStore,
         mockBioPrefHandler
     )
 
@@ -80,7 +80,7 @@ class HandleLoginTest : TestCase() {
         whenever(mockBioPrefHandler.getBioPref()).thenReturn(BiometricPreference.PASSCODE)
 
         runBlocking {
-            whenever(mockGetFromSecureStore(any(), any(), any())).thenAnswer {
+            whenever(mockGetFromTokenSecureStore(any(), any(), any())).thenAnswer {
                 (it.arguments[2] as (LocalAuthStatus) -> Unit).invoke(LocalAuthStatus.ManualSignIn)
             }
 
@@ -100,7 +100,7 @@ class HandleLoginTest : TestCase() {
         whenever(mockBioPrefHandler.getBioPref()).thenReturn(BiometricPreference.PASSCODE)
 
         runBlocking {
-            whenever(mockGetFromSecureStore(any(), any(), any())).thenAnswer {
+            whenever(mockGetFromTokenSecureStore(any(), any(), any())).thenAnswer {
                 (it.arguments[2] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.Success(token)
                 )

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenKtTest.kt
@@ -51,16 +51,16 @@ class SignOutScreenKtTest : TestCase() {
     @Test
     fun verifySignOutButtonSucceeds() {
         composeTestRule.onNode(ctaButton).performClick()
-        verify(signOutUseCase).invoke(composeTestRule.activity)
+        verify(signOutUseCase).invoke()
         verify(signIn).invoke()
     }
 
     @Test
     fun verifySignOutButtonFails() {
-        whenever(signOutUseCase.invoke(composeTestRule.activity))
+        whenever(signOutUseCase.invoke())
             .thenThrow(SignOutError(Exception("something went wrong")))
         composeTestRule.onNode(ctaButton).performClick()
-        verify(signOutUseCase).invoke(composeTestRule.activity)
+        verify(signOutUseCase).invoke()
         verify(signIn, never()).invoke()
         verify(goToSignOutError).invoke()
     }

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.signOut.ui
 
-import androidx.fragment.app.FragmentActivity
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
@@ -8,13 +7,12 @@ import uk.gov.onelogin.signOut.domain.SignOutUseCase
 
 class SignOutViewModelTest {
 
-    private val fragmentActivity: FragmentActivity = mock()
     private val signOutUseCase: SignOutUseCase = mock()
     private val sut = SignOutViewModel(signOutUseCase)
 
     @Test
     fun signOut() {
-        sut.signOut(fragmentActivity)
-        verify(signOutUseCase).invoke(fragmentActivity)
+        sut.signOut()
+        verify(signOutUseCase).invoke()
     }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
@@ -17,15 +17,15 @@ import uk.gov.onelogin.TestCase
 import uk.gov.onelogin.login.state.LocalAuthStatus
 
 @HiltAndroidTest
-class GetFromSecureStoreTest : TestCase() {
-    private lateinit var useCase: GetFromSecureStore
+class GetFromTokenSecureStoreTest : TestCase() {
+    private lateinit var useCase: GetFromTokenSecureStore
     private val mockSecureStore: SecureStore = mock()
 
     private val expectedStoreKey: String = "key"
 
     @Before
     fun setUp() {
-        useCase = GetFromSecureStoreImpl(mockSecureStore)
+        useCase = GetFromTokenSecureStoreImpl(mockSecureStore)
     }
 
     @Test

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.ui.home
 
-import androidx.fragment.app.FragmentActivity
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -47,15 +46,13 @@ class HomeScreenViewModelTest : TestCase() {
         runBlocking {
             whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
 
-            viewModel.saveTokens(composeTestRule.activity as FragmentActivity)
+            viewModel.saveTokens()
 
             verify(saveToSecureStore).invoke(
-                composeTestRule.activity as FragmentActivity,
                 Keys.ACCESS_TOKEN_KEY,
                 "test"
             )
             verify(saveToSecureStore).invoke(
-                composeTestRule.activity as FragmentActivity,
                 Keys.ID_TOKEN_KEY,
                 "id"
             )
@@ -74,14 +71,13 @@ class HomeScreenViewModelTest : TestCase() {
         runBlocking {
             whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
 
-            viewModel.saveTokens(composeTestRule.activity as FragmentActivity)
+            viewModel.saveTokens()
 
             verify(saveToSecureStore).invoke(
-                composeTestRule.activity as FragmentActivity,
                 Keys.ACCESS_TOKEN_KEY,
                 "test"
             )
-            verify(saveToSecureStore, times(0)).invoke(any(), eq(Keys.ID_TOKEN_KEY), any())
+            verify(saveToSecureStore, times(0)).invoke(any(), eq(Keys.ID_TOKEN_KEY))
             verify(saveTokenExpiry).invoke(testResponse.accessTokenExpirationTime)
         }
     }
@@ -91,10 +87,10 @@ class HomeScreenViewModelTest : TestCase() {
         runBlocking {
             whenever(tokenRepository.getTokenResponse()).thenReturn(null)
 
-            viewModel.saveTokens(composeTestRule.activity as FragmentActivity)
+            viewModel.saveTokens()
 
-            verify(saveToSecureStore, times(0)).invoke(any(), any(), any())
-            verify(saveToSecureStore, times(0)).invoke(any(), any(), any())
+            verify(saveToSecureStore, times(0)).invoke(any(), any())
+            verify(saveToSecureStore, times(0)).invoke(any(), any())
             verify(saveTokenExpiry, times(0)).invoke(any())
         }
     }

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
@@ -72,6 +72,37 @@ class HomeScreenViewModelTest : TestCase() {
     }
 
     @Test
+    fun saveTokenWhenTokensNotNullMissingPersistentId() {
+        val testResponse = TokenResponse(
+            tokenType = "test",
+            accessToken = "access",
+            accessTokenExpirationTime = 1L,
+            idToken = "id"
+        )
+
+        runBlocking {
+            whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
+            whenever(getPersistentId.invoke()).thenReturn(null)
+
+            viewModel.saveTokens()
+
+            verify(saveToSecureStore).invoke(
+                Keys.ACCESS_TOKEN_KEY,
+                "access"
+            )
+            verify(saveToSecureStore).invoke(
+                Keys.ID_TOKEN_KEY,
+                "id"
+            )
+            verify(saveTokenExpiry).invoke(testResponse.accessTokenExpirationTime)
+            verify(saveToOpenSecureStore, times(0)).invoke(
+                Keys.PERSISTENT_ID_KEY,
+                "persistentId"
+            )
+        }
+    }
+
+    @Test
     fun saveTokenWhenTokensNotNullIdTokenIsNull() {
         val testResponse = TokenResponse(
             tokenType = "test",

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLogin.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLogin.kt
@@ -8,7 +8,7 @@ import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.login.state.LocalAuthStatus
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.Keys
-import uk.gov.onelogin.tokens.usecases.GetFromSecureStore
+import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiry
 
 fun interface HandleLogin {
@@ -21,7 +21,7 @@ fun interface HandleLogin {
 class HandleLoginImpl @Inject constructor(
     private val getTokenExpiry: GetTokenExpiry,
     private val tokenRepository: TokenRepository,
-    private val getFromSecureStore: GetFromSecureStore,
+    private val getFromTokenSecureStore: GetFromTokenSecureStore,
     private val bioPrefHandler: BiometricPreferenceHandler
 ) : HandleLogin {
     override suspend fun invoke(
@@ -29,7 +29,7 @@ class HandleLoginImpl @Inject constructor(
         callback: (LocalAuthStatus) -> Unit
     ) {
         if (!isTokenExpiredOrMissing() && bioPrefHandler.getBioPref() != BiometricPreference.NONE) {
-            getFromSecureStore(fragmentActivity, Keys.ACCESS_TOKEN_KEY) {
+            getFromTokenSecureStore(fragmentActivity, Keys.ACCESS_TOKEN_KEY) {
                 if (it is LocalAuthStatus.Success) {
                     tokenRepository.setTokenResponse(
                         TokenResponse(

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
@@ -108,3 +108,19 @@ fun String.extractEmailFromIdToken(): String? {
         return null
     }
 }
+
+@OptIn(ExperimentalEncodingApi::class)
+@Suppress("TooGenericExceptionCaught")
+fun String.extractPersistentIdFromIdToken(): String? {
+    try {
+        val bodyEncoded = this.split(".")[1]
+        val body = String(Base64.decode(bodyEncoded))
+        val data = Json.parseToJsonElement(body)
+        val email = data.jsonObject["persistent_id"]
+        val stripEmail = email?.toString()?.removeSurrounding("\"")
+        return stripEmail
+    } catch (e: Exception) {
+        Log.e(this::class.simpleName, e.message, e)
+        return null
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
@@ -116,8 +116,8 @@ fun String.extractPersistentIdFromIdToken(): String? {
         val bodyEncoded = this.split(".")[1]
         val body = String(Base64.decode(bodyEncoded))
         val data = Json.parseToJsonElement(body)
-        val email = data.jsonObject["persistent_id"]
-        val stripEmail = email?.toString()?.removeSurrounding("\"")
+        val id = data.jsonObject["persistent_id"]
+        val stripEmail = id?.toString()?.removeSurrounding("\"")
         return stripEmail
     } catch (e: Exception) {
         Log.e(this::class.simpleName, e.message, e)

--- a/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
@@ -1,13 +1,12 @@
 package uk.gov.onelogin.signOut.domain
 
-import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 
 fun interface SignOutUseCase {
-    operator fun invoke(context: FragmentActivity)
+    operator fun invoke()
 }
 
 @Suppress("TooGenericExceptionCaught")
@@ -17,10 +16,10 @@ class SignOutUseCaseImpl @Inject constructor(
     private val bioPrefHandler: BiometricPreferenceHandler
 ) : SignOutUseCase {
     @Throws(SignOutError::class)
-    override fun invoke(context: FragmentActivity) {
+    override fun invoke() {
         try {
             removeTokenExpiry()
-            removeAllSecureStoreData(context)
+            removeAllSecureStoreData()
             bioPrefHandler.clear()
         } catch (e: Throwable) {
             throw SignOutError(e)

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
@@ -2,14 +2,12 @@ package uk.gov.onelogin.signOut.ui
 
 import android.util.Log
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.pages.AlertPage
@@ -23,7 +21,6 @@ fun SignOutScreen(
     goToSignOutError: () -> Unit,
     viewModel: SignOutViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current as FragmentActivity
     AlertPage(
         alertPageParameters = AlertPageParameters(
             title = R.string.app_signOutConfirmationTitle,
@@ -43,7 +40,7 @@ fun SignOutScreen(
             },
             onPrimary = {
                 try {
-                    viewModel.signOut(context)
+                    viewModel.signOut()
                     goToSignIn()
                 } catch (e: SignOutError) {
                     Log.e("SignOutScreen", e.message, e)

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.signOut.ui
 
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -10,7 +9,7 @@ import uk.gov.onelogin.signOut.domain.SignOutUseCase
 class SignOutViewModel @Inject constructor(
     private val signOutUseCase: SignOutUseCase
 ) : ViewModel() {
-    fun signOut(context: FragmentActivity) {
-        signOutUseCase(context)
+    fun signOut() {
+        signOutUseCase()
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
@@ -5,6 +5,7 @@ object Keys {
     const val OPEN_SECURE_STORE_ID = "open_store"
     const val ACCESS_TOKEN_KEY = "access_token"
     const val ID_TOKEN_KEY = "id_token"
+    const val PERSISTENT_ID_KEY = "persistent_id"
     const val TOKEN_SHARED_PREFS = "token_shared_prefs"
     const val TOKEN_EXPIRY_KEY = "token_expiry"
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/Keys.kt
@@ -1,7 +1,8 @@
 package uk.gov.onelogin.tokens
 
 object Keys {
-    const val SECURE_STORE_ID = "token_store"
+    const val TOKEN_SECURE_STORE_ID = "token_store"
+    const val OPEN_SECURE_STORE_ID = "open_store"
     const val ACCESS_TOKEN_KEY = "access_token"
     const val ID_TOKEN_KEY = "id_token"
     const val TOKEN_SHARED_PREFS = "token_shared_prefs"

--- a/app/src/main/java/uk/gov/onelogin/tokens/SecureStoreModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/SecureStoreModule.kt
@@ -1,10 +1,15 @@
 package uk.gov.onelogin.tokens
 
+import android.content.Context
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 import javax.inject.Singleton
+import uk.gov.android.securestore.AccessControlLevel
+import uk.gov.android.securestore.SecureStorageConfiguration
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.SharedPrefsStore
 import uk.gov.onelogin.tokens.usecases.AutoInitialiseSecureStore
@@ -16,7 +21,22 @@ object SecureStoreModule {
 
     @Provides
     @Singleton
-    fun providesSecureStore(): SecureStore = SharedPrefsStore()
+    @Named("Token")
+    fun providesTokenSecureStore(): SecureStore = SharedPrefsStore()
+
+    @Provides
+    @Singleton
+    @Named("Open")
+    fun providesOpenSecureStore(
+        @ApplicationContext
+        context: Context
+    ): SecureStore = SharedPrefsStore().also {
+        val configuration = SecureStorageConfiguration(
+            Keys.OPEN_SECURE_STORE_ID,
+            AccessControlLevel.OPEN
+        )
+        it.init(context, configuration)
+    }
 
     @Provides
     @Singleton

--- a/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
@@ -6,14 +6,18 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import uk.gov.onelogin.tokens.usecases.GetEmail
 import uk.gov.onelogin.tokens.usecases.GetEmailImpl
-import uk.gov.onelogin.tokens.usecases.GetFromSecureStore
-import uk.gov.onelogin.tokens.usecases.GetFromSecureStoreImpl
+import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
+import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStoreImpl
+import uk.gov.onelogin.tokens.usecases.GetPersistentId
+import uk.gov.onelogin.tokens.usecases.GetPersistentIdImpl
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiry
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiryImpl
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreDataImpl
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiryImpl
+import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
+import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
@@ -26,13 +30,18 @@ import uk.gov.onelogin.tokens.verifier.JwtVerifier
 interface TokenModule {
     @Binds
     fun bindGetFromSecureStore(
-        getFromSecureStore: GetFromSecureStoreImpl
-    ): GetFromSecureStore
+        getFromSecureStore: GetFromTokenSecureStoreImpl
+    ): GetFromTokenSecureStore
 
     @Binds
     fun bindSaveToSecureStore(
         saveToSecureStore: SaveToSecureStoreImpl
     ): SaveToSecureStore
+
+    @Binds
+    fun bindSaveToOpenSecureStore(
+        saveToOpenSecureStore: SaveToOpenSecureStoreImpl
+    ): SaveToOpenSecureStore
 
     @Binds
     fun bindClearAllSecureStore(
@@ -53,6 +62,11 @@ interface TokenModule {
     fun bindGetEmail(
         getEmail: GetEmailImpl
     ): GetEmail
+
+    @Binds
+    fun bindGetPersistentId(
+        getPersistentId: GetPersistentIdImpl
+    ): GetPersistentId
 
     @Binds
     fun bindSaveTokenExpiry(

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/AutoInitialiseSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/AutoInitialiseSecureStore.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin.tokens.usecases
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import javax.inject.Named
 import uk.gov.android.securestore.SecureStorageConfiguration
 import uk.gov.android.securestore.SecureStore
 import uk.gov.onelogin.login.biooptin.BiometricPreference
@@ -12,7 +13,7 @@ import uk.gov.onelogin.tokens.Mapper
 
 fun interface AutoInitialiseSecureStore {
     /**
-     * Initialise the secure store using id [Keys.SECURE_STORE_ID].
+     * Initialise the secure store using id [Keys.TOKEN_SECURE_STORE_ID].
      * The initialisation of the secure store only happens if [BiometricPreference] set
      */
     operator fun invoke()
@@ -20,6 +21,7 @@ fun interface AutoInitialiseSecureStore {
 
 class AutoInitialiseSecureStoreImpl @Inject constructor(
     private val biometricPreferenceHandler: BiometricPreferenceHandler,
+    @Named("Token")
     private val secureStore: SecureStore,
     @ApplicationContext
     private val context: Context
@@ -28,7 +30,7 @@ class AutoInitialiseSecureStoreImpl @Inject constructor(
         val bioPref = biometricPreferenceHandler.getBioPref()
         if (bioPref == null || bioPref == BiometricPreference.NONE) return
         val configuration = SecureStorageConfiguration(
-            Keys.SECURE_STORE_ID,
+            Keys.TOKEN_SECURE_STORE_ID,
             Mapper.mapAccessControlLevel(bioPref)
         )
         secureStore.init(context, configuration)

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromSecureStore.kt
@@ -2,6 +2,7 @@ package uk.gov.onelogin.tokens.usecases
 
 import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
+import javax.inject.Named
 import uk.gov.android.onelogin.R
 import uk.gov.android.securestore.RetrievalEvent
 import uk.gov.android.securestore.SecureStore
@@ -25,6 +26,7 @@ fun interface GetFromSecureStore {
 }
 
 class GetFromSecureStoreImpl @Inject constructor(
+    @Named("Token")
     private val secureStore: SecureStore
 ) : GetFromSecureStore {
     override suspend fun invoke(

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
@@ -10,7 +10,7 @@ import uk.gov.android.securestore.authentication.AuthenticatorPromptConfiguratio
 import uk.gov.android.securestore.error.SecureStoreErrorType
 import uk.gov.onelogin.login.state.LocalAuthStatus
 
-fun interface GetFromSecureStore {
+fun interface GetFromTokenSecureStore {
     /**
      * Use case for getting data from a secure store instance.
      *
@@ -25,10 +25,10 @@ fun interface GetFromSecureStore {
     )
 }
 
-class GetFromSecureStoreImpl @Inject constructor(
+class GetFromTokenSecureStoreImpl @Inject constructor(
     @Named("Token")
     private val secureStore: SecureStore
-) : GetFromSecureStore {
+) : GetFromTokenSecureStore {
     override suspend fun invoke(
         context: FragmentActivity,
         key: String,

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
@@ -18,7 +18,6 @@ class GetPersistentIdImpl @Inject constructor(
 ) : GetPersistentId {
     override fun invoke(): String? {
         val idToken: String = tokenRepository.getTokenResponse()?.idToken ?: return null
-        val id = idToken.extractPersistentIdFromIdToken()
-        return id
+        return idToken.extractPersistentIdFromIdToken()
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
@@ -1,0 +1,24 @@
+package uk.gov.onelogin.tokens.usecases
+
+import javax.inject.Inject
+import uk.gov.onelogin.login.usecase.extractPersistentIdFromIdToken
+import uk.gov.onelogin.repositiories.TokenRepository
+
+fun interface GetPersistentId {
+    /**
+     * Use case to get the persistent id from the id token
+     *
+     * @return persistent id as a string or null if it fails to retrieve it
+     */
+    operator fun invoke(): String?
+}
+
+class GetPersistentIdImpl @Inject constructor(
+    val tokenRepository: TokenRepository
+) : GetPersistentId {
+    override fun invoke(): String? {
+        val idToken: String = tokenRepository.getTokenResponse()?.idToken ?: return null
+        val id = idToken.extractPersistentIdFromIdToken()
+        return id
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/RemoveAllSecureStoreData.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/RemoveAllSecureStoreData.kt
@@ -1,8 +1,8 @@
 package uk.gov.onelogin.tokens.usecases
 
 import android.util.Log
-import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
+import javax.inject.Named
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
 import uk.gov.onelogin.tokens.Keys
@@ -10,25 +10,20 @@ import uk.gov.onelogin.tokens.Keys
 fun interface RemoveAllSecureStoreData {
     /**
      * Use case for removing all data from the secure store instance
-     *
-     * @param context Must be a FragmentActivity context (due to authentication prompt)
      */
-    operator fun invoke(
-        context: FragmentActivity
-    )
+    operator fun invoke()
 }
 
 class RemoveAllSecureStoreDataImpl @Inject constructor(
-    private val secureStore: SecureStore
+    @Named("Token")
+    private val tokenSecureStore: SecureStore
 ) : RemoveAllSecureStoreData {
-    override fun invoke(context: FragmentActivity) {
+    override fun invoke() {
         try {
-            secureStore.delete(
-                context = context,
+            tokenSecureStore.delete(
                 key = Keys.ACCESS_TOKEN_KEY
             )
-            secureStore.delete(
-                context = context,
+            tokenSecureStore.delete(
                 key = Keys.ID_TOKEN_KEY
             )
         } catch (e: SecureStorageError) {

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
@@ -6,9 +6,9 @@ import javax.inject.Named
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
 
-fun interface SaveToSecureStore {
+fun interface SaveToOpenSecureStore {
     /**
-     * Use case for saving data into a secure store instance
+     * Use case for saving data into an open secure store instance
      *
      * @param key [String] value of key value pair to save
      * @param value [String] value of value in key value pair to save
@@ -19,10 +19,10 @@ fun interface SaveToSecureStore {
     )
 }
 
-class SaveToSecureStoreImpl @Inject constructor(
-    @Named("Token")
+class SaveToOpenSecureStoreImpl @Inject constructor(
+    @Named("Open")
     private val secureStore: SecureStore
-) : SaveToSecureStore {
+) : SaveToOpenSecureStore {
     override suspend fun invoke(key: String, value: String) {
         try {
             secureStore.upsert(

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
@@ -6,12 +6,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.pages.TitledPage
@@ -26,7 +24,7 @@ fun HomeScreen(
     viewModel: HomeScreenViewModel = hiltViewModel(),
     openDeveloperPanel: () -> Unit = { }
 ) {
-    viewModel.saveTokens(LocalContext.current as FragmentActivity)
+    viewModel.saveTokens()
     val tokens = viewModel.getTokens()
     val email = viewModel.email
     TitledPage(

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.ui.home
 
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,19 +21,17 @@ class HomeScreenViewModel @Inject constructor(
 ) : ViewModel() {
     val email = getEmail() ?: ""
 
-    fun saveTokens(context: FragmentActivity) {
+    fun saveTokens() {
         val tokens = tokenRepository.getTokenResponse()
         viewModelScope.launch {
             tokens?.let { tokenResponse ->
                 saveTokenExpiry(tokenResponse.accessTokenExpirationTime)
                 saveToSecureStore(
-                    context = context,
                     key = Keys.ACCESS_TOKEN_KEY,
                     value = tokenResponse.accessToken
                 )
                 tokenResponse.idToken?.let {
                     saveToSecureStore(
-                        context = context,
                         key = Keys.ID_TOKEN_KEY,
                         value = it
                     )

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
@@ -9,6 +9,8 @@ import uk.gov.android.authentication.TokenResponse
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.Keys
 import uk.gov.onelogin.tokens.usecases.GetEmail
+import uk.gov.onelogin.tokens.usecases.GetPersistentId
+import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
 
@@ -16,7 +18,9 @@ import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
 class HomeScreenViewModel @Inject constructor(
     private val tokenRepository: TokenRepository,
     private val saveToSecureStore: SaveToSecureStore,
+    private val saveToOpenSecureStore: SaveToOpenSecureStore,
     private val saveTokenExpiry: SaveTokenExpiry,
+    private val getPersistentId: GetPersistentId,
     getEmail: GetEmail
 ) : ViewModel() {
     val email = getEmail() ?: ""
@@ -31,6 +35,10 @@ class HomeScreenViewModel @Inject constructor(
                     value = tokenResponse.accessToken
                 )
                 tokenResponse.idToken?.let {
+                    saveToOpenSecureStore(
+                        key = Keys.PERSISTENT_ID_KEY,
+                        value = getPersistentId() ?: ""
+                    )
                     saveToSecureStore(
                         key = Keys.ID_TOKEN_KEY,
                         value = it

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
@@ -35,10 +35,12 @@ class HomeScreenViewModel @Inject constructor(
                     value = tokenResponse.accessToken
                 )
                 tokenResponse.idToken?.let {
-                    saveToOpenSecureStore(
-                        key = Keys.PERSISTENT_ID_KEY,
-                        value = getPersistentId() ?: ""
-                    )
+                    getPersistentId()?.let { id ->
+                        saveToOpenSecureStore(
+                            key = Keys.PERSISTENT_ID_KEY,
+                            value = id
+                        )
+                    }
                     saveToSecureStore(
                         key = Keys.ID_TOKEN_KEY,
                         value = it

--- a/app/src/test/java/uk/gov/onelogin/login/usecase/VerifyIdTokenTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/usecase/VerifyIdTokenTest.kt
@@ -16,9 +16,14 @@ class VerifyIdTokenTest {
 
     // the header of the web token contains a 'kid' for one of the keys below
     private val idToken =
-        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI" +
-            "6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZWJkZjkzZCJ9" +
-            ".eyJlbWFpbCI6ImVtYWlsQG1haWwuY29tIn0"
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZ" +
+            "WJkZjkzZCJ9.eyJhdWQiOiJHRVV6a0V6SVFVOXJmYmdBWmJzal9fMUVOUU0iLCJpc3MiOiJodHRwcz" +
+            "ovL3Rva2VuLmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiOWQwZjIxZGUtMmZkNy00MjdiLWE2" +
+            "ZGYtMDdjZDBkOTVlM2I2IiwicGVyc2lzdGVudF9pZCI6ImNjODkzZWNlLWI2YmQtNDQ0ZC05YmI0LW" +
+            "RlYzZmNTc3OGU1MCIsImlhdCI6MTcyMTk5ODE3OCwiZXhwIjoxNzIxOTk4MzU4LCJub25jZSI6InRl" +
+            "c3Rfbm9uY2UiLCJlbWFpbCI6Im1vY2tAZW1haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWV9.G" +
+            "1uQ9z2i-214kEmmtK7hEHRsgqJdk7AXjz_CaJDiuuqSyHZ4W48oE1karDBA-pKWpADdBpHeUC-eCj" +
+            "jfBObjOg"
     private val idTokenMissingEmail =
         "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI" +
             "6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZWJkZjkzZCJ9" +

--- a/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.signOut.domain
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -15,7 +14,6 @@ class SignOutUseCaseTest {
     private val removeAllSecureStoreData: RemoveAllSecureStoreData = mock()
     private val removeTokenExpiry: RemoveTokenExpiry = mock()
     private val bioPrefHandler: BiometricPreferenceHandler = mock()
-    private val fragmentActivity: FragmentActivity = mock()
 
     private val sut =
         SignOutUseCaseImpl(removeAllSecureStoreData, removeTokenExpiry, bioPrefHandler)
@@ -23,11 +21,11 @@ class SignOutUseCaseTest {
     @Test
     operator fun invoke() {
         // WHEN we call sign out use case
-        sut.invoke(fragmentActivity)
+        sut.invoke()
 
         // THEN it clears all the required data
         verify(removeTokenExpiry).invoke()
-        verify(removeAllSecureStoreData).invoke(fragmentActivity)
+        verify(removeAllSecureStoreData).invoke()
         verify(bioPrefHandler).clear()
     }
 
@@ -37,7 +35,7 @@ class SignOutUseCaseTest {
             .thenThrow(RuntimeException("something went terribly bad"))
 
         val exception: SignOutError = Assertions.assertThrows(SignOutError::class.java) {
-            sut.invoke(fragmentActivity)
+            sut.invoke()
         }
         assertTrue(exception.error.message!!.contains("something went terribly bad"))
     }

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/AutoInitialiseSecureStoreTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/AutoInitialiseSecureStoreTest.kt
@@ -54,7 +54,7 @@ class AutoInitialiseSecureStoreTest {
         useCase.invoke()
 
         val expectedConfiguration = SecureStorageConfiguration(
-            Keys.SECURE_STORE_ID,
+            Keys.TOKEN_SECURE_STORE_ID,
             AccessControlLevel.PASSCODE
         )
         verify(mockSecureStore, times(1)).init(mockContext, expectedConfiguration)
@@ -67,7 +67,7 @@ class AutoInitialiseSecureStoreTest {
         useCase.invoke()
 
         val expectedConfiguration = SecureStorageConfiguration(
-            Keys.SECURE_STORE_ID,
+            Keys.TOKEN_SECURE_STORE_ID,
             AccessControlLevel.PASSCODE_AND_CURRENT_BIOMETRICS
         )
         verify(mockSecureStore, times(1)).init(mockContext, expectedConfiguration)

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/GetPersistentIdImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/GetPersistentIdImplTest.kt
@@ -1,0 +1,74 @@
+package uk.gov.onelogin.tokens.usecases
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.TokenResponse
+import uk.gov.onelogin.repositiories.TokenRepository
+
+class GetPersistentIdImplTest {
+
+    private val expectedPersitentId = "cc893ece-b6bd-444d-9bb4-dec6f5778e50"
+    private val idTokenWithId =
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjE2ZGI2NTg3LTU0NDUtNDVkNi1hN2Q5LTk4NzgxZ" +
+            "WJkZjkzZCJ9.eyJhdWQiOiJHRVV6a0V6SVFVOXJmYmdBWmJzal9fMUVOUU0iLCJpc3MiOiJodHRwcz" +
+            "ovL3Rva2VuLmJ1aWxkLmFjY291bnQuZ292LnVrIiwic3ViIjoiOWQwZjIxZGUtMmZkNy00MjdiLWE2" +
+            "ZGYtMDdjZDBkOTVlM2I2IiwicGVyc2lzdGVudF9pZCI6ImNjODkzZWNlLWI2YmQtNDQ0ZC05YmI0LW" +
+            "RlYzZmNTc3OGU1MCIsImlhdCI6MTcyMTk5ODE3OCwiZXhwIjoxNzIxOTk4MzU4LCJub25jZSI6InRl" +
+            "c3Rfbm9uY2UiLCJlbWFpbCI6Im1vY2tAZW1haWwuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWV9.G" +
+            "1uQ9z2i-214kEmmtK7hEHRsgqJdk7AXjz_CaJDiuuqSyHZ4W48oE1karDBA-pKWpADdBpHeUC-eCj" +
+            "jfBObjOg"
+    private val idTokenWithoutId = "eyJhbGciOiJIUzI1NiJ9" +
+        ".e30." + // no id in the payload
+        "ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo"
+    private val tokenResponse: TokenResponse = mock()
+    private val tokenRepository: TokenRepository = mock()
+
+    val sut = GetPersistentIdImpl(tokenRepository)
+
+    @BeforeEach
+    fun setUp() {
+        whenever(tokenResponse.idToken).thenReturn(idTokenWithId)
+        whenever(tokenRepository.getTokenResponse()).thenReturn(tokenResponse)
+    }
+
+    @Test
+    fun successScenario() {
+        // Given id token contains id
+        whenever(tokenResponse.idToken).thenReturn(idTokenWithId)
+        whenever(tokenRepository.getTokenResponse()).thenReturn(tokenResponse)
+
+        val idResponse = sut.invoke()
+        assertEquals(expectedPersitentId, idResponse)
+    }
+
+    @Test
+    fun missingIdScenario() {
+        // Given id token is missing the id
+        whenever(tokenResponse.idToken).thenReturn(idTokenWithoutId)
+        whenever(tokenRepository.getTokenResponse()).thenReturn(tokenResponse)
+
+        val idResponse = sut.invoke()
+        assertEquals(null, idResponse)
+    }
+
+    @Test
+    fun missingTokenScenario() {
+        // Given token is null
+        whenever(tokenRepository.getTokenResponse()).thenReturn(null)
+
+        val idResponse = sut.invoke()
+        assertEquals(null, idResponse)
+    }
+
+    @Test
+    fun missingIdTokenScenario() {
+        // Given id token is null
+        whenever(tokenResponse.idToken).thenReturn(null)
+
+        val idResponse = sut.invoke()
+        assertEquals(null, idResponse)
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/RemoveAllSecureStoreDataTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/RemoveAllSecureStoreDataTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.tokens.usecases
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -22,7 +21,6 @@ import uk.gov.onelogin.tokens.Keys
 @ExtendWith(CoroutinesTestExtension::class)
 class RemoveAllSecureStoreDataTest {
     private lateinit var useCase: RemoveAllSecureStoreData
-    private val mockFragmentActivity: FragmentActivity = mock()
     private val mockSecureStore: SecureStore = mock()
 
     @BeforeEach
@@ -32,15 +30,13 @@ class RemoveAllSecureStoreDataTest {
 
     @Test
     fun `removes access token and id token`() = runTest {
-        useCase.invoke(mockFragmentActivity)
+        useCase.invoke()
 
         verify(mockSecureStore).delete(
-            Keys.ACCESS_TOKEN_KEY,
-            mockFragmentActivity
+            Keys.ACCESS_TOKEN_KEY
         )
         verify(mockSecureStore).delete(
-            Keys.ID_TOKEN_KEY,
-            mockFragmentActivity
+            Keys.ID_TOKEN_KEY
         )
     }
 
@@ -48,13 +44,12 @@ class RemoveAllSecureStoreDataTest {
     fun `secure store exception is propagated up`() = runTest {
         whenever(
             mockSecureStore.delete(
-                Keys.ACCESS_TOKEN_KEY,
-                mockFragmentActivity
+                Keys.ACCESS_TOKEN_KEY
             )
         ).thenThrow(SecureStorageError(Exception("something went wrong")))
 
         val exception: SecureStorageError = assertThrows(SecureStorageError::class.java) {
-            useCase.invoke(mockFragmentActivity)
+            useCase.invoke()
         }
         assertEquals(SecureStoreErrorType.GENERAL, exception.type)
         assertTrue(exception.message!!.contains("something went wrong"))

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/SaveToSecureStoreTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/SaveToSecureStoreTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.tokens.usecases
 
-import androidx.fragment.app.FragmentActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -19,7 +18,6 @@ import uk.gov.onelogin.extensions.CoroutinesTestExtension
 @ExtendWith(CoroutinesTestExtension::class)
 class SaveToSecureStoreTest {
     private lateinit var useCase: SaveToSecureStore
-    private val mockFragmentActivity: FragmentActivity = mock()
     private val mockSecureStore: SecureStore = mock()
 
     private val expectedStoreKey: String = "key"
@@ -32,23 +30,22 @@ class SaveToSecureStoreTest {
 
     @Test
     fun `does not throw - when SecureStorageError thrown`() = runTest {
-        whenever(mockSecureStore.upsert(any(), any(), any())).thenThrow(
+        whenever(mockSecureStore.upsert(any(), any())).thenThrow(
             SecureStorageError(Exception("Some error"))
         )
 
         assertDoesNotThrow {
-            useCase.invoke(mockFragmentActivity, expectedStoreKey, expectedStoreValue)
+            useCase.invoke(expectedStoreKey, expectedStoreValue)
         }
     }
 
     @Test
     fun `saves value successfully`() = runTest {
-        useCase.invoke(mockFragmentActivity, expectedStoreKey, expectedStoreValue)
+        useCase.invoke(expectedStoreKey, expectedStoreValue)
 
         verify(mockSecureStore).upsert(
             expectedStoreKey,
-            expectedStoreValue,
-            mockFragmentActivity
+            expectedStoreValue
         )
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
@@ -1,9 +1,9 @@
 package uk.gov.onelogin.ui.home
 
-import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -11,7 +11,8 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.TokenResponse
-import uk.gov.onelogin.TestCase
+import uk.gov.onelogin.extensions.CoroutinesTestExtension
+import uk.gov.onelogin.extensions.InstantExecutorExtension
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.Keys
 import uk.gov.onelogin.tokens.usecases.GetEmail
@@ -20,8 +21,8 @@ import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
 
-@HiltAndroidTest
-class HomeScreenViewModelTest : TestCase() {
+@ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
+class HomeScreenViewModelTest {
     private val tokenRepository: TokenRepository = mock()
     private val saveToSecureStore: SaveToSecureStore = mock()
     private val saveToOpenSecureStore: SaveToOpenSecureStore = mock()
@@ -49,12 +50,12 @@ class HomeScreenViewModelTest : TestCase() {
             idToken = "id"
         )
 
+        whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
+        whenever(getPersistentId.invoke()).thenReturn("persistentId")
+
+        viewModel.saveTokens()
+
         runBlocking {
-            whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
-            whenever(getPersistentId.invoke()).thenReturn("persistentId")
-
-            viewModel.saveTokens()
-
             verify(saveToSecureStore).invoke(
                 Keys.ACCESS_TOKEN_KEY,
                 "access"
@@ -80,12 +81,11 @@ class HomeScreenViewModelTest : TestCase() {
             idToken = "id"
         )
 
+        whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
+        whenever(getPersistentId.invoke()).thenReturn(null)
+
+        viewModel.saveTokens()
         runBlocking {
-            whenever(tokenRepository.getTokenResponse()).thenReturn(testResponse)
-            whenever(getPersistentId.invoke()).thenReturn(null)
-
-            viewModel.saveTokens()
-
             verify(saveToSecureStore).invoke(
                 Keys.ACCESS_TOKEN_KEY,
                 "access"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,7 @@ authentication = "uk.gov.android:authentication:0.5.0"
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
-secure-store = { group = "uk.gov.android", name = "securestore", version = "0.5.0" }
+secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.2" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
- Update secure store version and small refactor
- SecureStoreModule injects two versions of secure store
- SaveToOpenSecureStore created to access 'new' secure store
- GetPersistentId pulls persistent id from id token
- some refactoring of get token from token secure store
- logic in HomeScreenViewModel to extract and save persistent id