### PR TITLE
feat: Implement DeleteWalletData

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,11 +61,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
@@ -152,7 +152,7 @@ class SplashScreenViewModelTest : TestCase() {
         viewModel.onResume(mockLifeCycleOwner)
 
         // WHEN we call login
-        viewModel.login(composeTestRule.activity as FragmentActivity, fromLockScreen)
+        viewModel.login(composeTestRule.activity, fromLockScreen)
 
         // THEN do NOT login (as the app will be going to background)
         verify(mockHandleLogin, times(1)).invoke(any(), any())

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenKtTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performClick
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -30,6 +31,7 @@ import uk.gov.onelogin.features.FeaturesModule
 import uk.gov.onelogin.features.StsFeatureFlag
 import uk.gov.onelogin.login.authentication.LoginSessionModule
 import uk.gov.onelogin.network.di.NetworkModule
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
 import uk.gov.onelogin.wallet.WalletModule
 
 @HiltAndroidTest
@@ -58,6 +60,9 @@ class WelcomeScreenKtTest : TestCase() {
 
     @BindValue
     val walletSdk: WalletSdk = mock()
+
+    @BindValue
+    val deleteWalletDataUseCase: DeleteWalletDataUseCase = mock()
 
     private var navigateToOfflineErrorScreenCalled = false
     private var shouldTryAgainCalled = false
@@ -89,7 +94,7 @@ class WelcomeScreenKtTest : TestCase() {
     }
 
     @Test
-    fun opensWebLoginViaCustomTab() {
+    fun opensWebLoginViaCustomTab() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(false)
 
@@ -133,7 +138,7 @@ class WelcomeScreenKtTest : TestCase() {
     }
 
     @Test
-    fun opensWebLoginViaCustomTab_StsFlagOn() {
+    fun opensWebLoginViaCustomTab_StsFlagOn() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
         composeTestRule.setContent {
@@ -190,7 +195,7 @@ class WelcomeScreenKtTest : TestCase() {
     }
 
     @Test
-    fun loginFiresAutomaticallyIfOnlineAndShouldTryAgainIsTrue() {
+    fun loginFiresAutomaticallyIfOnlineAndShouldTryAgainIsTrue() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
         composeTestRule.setContent {

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenKtTest.kt
@@ -7,26 +7,39 @@ import androidx.compose.ui.test.performClick
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.onelogin.R
+import uk.gov.android.wallet.sdk.WalletSdk
 import uk.gov.onelogin.TestCase
 import uk.gov.onelogin.signOut.SignOutModule
 import uk.gov.onelogin.signOut.domain.SignOutError
 import uk.gov.onelogin.signOut.domain.SignOutUseCase
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
+import uk.gov.onelogin.wallet.WalletModule
 
 @HiltAndroidTest
 @UninstallModules(
-    SignOutModule::class
+    SignOutModule::class,
+    WalletModule::class
 )
 class SignOutScreenKtTest : TestCase() {
 
     @BindValue
     val signOutUseCase: SignOutUseCase = mock()
+
+    @BindValue
+    val walletSdk: WalletSdk = mock()
+
+    @BindValue
+    val deleteWalletDataUseCase: DeleteWalletDataUseCase = mock()
     private val goBack: () -> Unit = mock()
     private val signIn: () -> Unit = mock()
     private val goToSignOutError: () -> Unit = mock()
@@ -49,18 +62,18 @@ class SignOutScreenKtTest : TestCase() {
     }
 
     @Test
-    fun verifySignOutButtonSucceeds() {
+    fun verifySignOutButtonSucceeds() = runBlocking {
         composeTestRule.onNode(ctaButton).performClick()
-        verify(signOutUseCase).invoke()
+        verify(signOutUseCase).invoke(any())
         verify(signIn).invoke()
     }
 
-    @Test
-    fun verifySignOutButtonFails() {
-        whenever(signOutUseCase.invoke())
+    @Test(expected = Throwable::class)
+    fun verifySignOutButtonFails() = runTest {
+        whenever(signOutUseCase.invoke(any()))
             .thenThrow(SignOutError(Exception("something went wrong")))
         composeTestRule.onNode(ctaButton).performClick()
-        verify(signOutUseCase).invoke()
+        verify(signOutUseCase).invoke(any())
         verify(signIn, never()).invoke()
         verify(goToSignOutError).invoke()
     }

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenTest.kt
@@ -30,7 +30,7 @@ import uk.gov.onelogin.wallet.WalletModule
     SignOutModule::class,
     WalletModule::class
 )
-class SignOutScreenKtTest : TestCase() {
+class SignOutScreenTest : TestCase() {
 
     @BindValue
     val signOutUseCase: SignOutUseCase = mock()

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
@@ -1,18 +1,22 @@
 package uk.gov.onelogin.signOut.ui
 
+import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import uk.gov.onelogin.signOut.domain.SignOutUseCase
 
 class SignOutViewModelTest {
 
     private val signOutUseCase: SignOutUseCase = mock()
+    private val activityFragment: FragmentActivity = mock()
     private val sut = SignOutViewModel(signOutUseCase)
 
     @Test
-    fun signOut() {
-        sut.signOut()
-        verify(signOutUseCase).invoke()
+    fun signOut() = runBlocking {
+        sut.signOut(activityFragment)
+        verify(signOutUseCase).invoke(any())
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavScreen.kt
@@ -96,7 +96,7 @@ fun MainNavScreen(
                 HomeScreen(openDeveloperPanel = openDeveloperPanel)
             }
             composable(BottomNavDestination.Wallet.key) {
-                walletScreenViewModel.walletSdk.WalletApp(deeplink = "", adminEnabled = true)
+                walletScreenViewModel.walletSdk.WalletApp(deeplink = "", adminEnabled = false)
             }
             composable(BottomNavDestination.Profile.key) {
                 ProfileScreen(openSignOutScreen = openSignOutScreen)

--- a/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
@@ -24,7 +24,7 @@ class SignOutUseCaseImpl @Inject constructor(
             removeTokenExpiry()
             removeAllSecureStoreData()
             bioPrefHandler.clear()
-            deleteWalletData(activityFragment)
+            deleteWalletData.invoke(activityFragment)
         } catch (e: Throwable) {
             throw SignOutError(e)
         }

--- a/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
@@ -8,7 +8,7 @@ import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
 
 fun interface SignOutUseCase {
-    suspend operator fun invoke(activityFragment: FragmentActivity)
+    suspend fun invoke(activityFragment: FragmentActivity)
 }
 
 @Suppress("TooGenericExceptionCaught")

--- a/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/domain/SignOutUseCase.kt
@@ -1,26 +1,30 @@
 package uk.gov.onelogin.signOut.domain
 
+import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
 
 fun interface SignOutUseCase {
-    operator fun invoke()
+    suspend operator fun invoke(activityFragment: FragmentActivity)
 }
 
 @Suppress("TooGenericExceptionCaught")
 class SignOutUseCaseImpl @Inject constructor(
     private val removeAllSecureStoreData: RemoveAllSecureStoreData,
     private val removeTokenExpiry: RemoveTokenExpiry,
-    private val bioPrefHandler: BiometricPreferenceHandler
+    private val bioPrefHandler: BiometricPreferenceHandler,
+    private val deleteWalletData: DeleteWalletDataUseCase
 ) : SignOutUseCase {
     @Throws(SignOutError::class)
-    override fun invoke() {
+    override suspend fun invoke(activityFragment: FragmentActivity) {
         try {
             removeTokenExpiry()
             removeAllSecureStoreData()
             bioPrefHandler.clear()
+            deleteWalletData(activityFragment)
         } catch (e: Throwable) {
             throw SignOutError(e)
         }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
@@ -2,12 +2,14 @@ package uk.gov.onelogin.signOut.ui
 
 import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.pages.AlertPage
@@ -21,6 +23,8 @@ fun SignOutScreen(
     goToSignOutError: () -> Unit,
     viewModel: SignOutViewModel = hiltViewModel()
 ) {
+    // Needed for deleteWalletData
+    val fragmentActivity = LocalContext.current as FragmentActivity
     AlertPage(
         alertPageParameters = AlertPageParameters(
             title = R.string.app_signOutConfirmationTitle,
@@ -40,7 +44,7 @@ fun SignOutScreen(
             },
             onPrimary = {
                 try {
-                    viewModel.signOut()
+                    viewModel.signOut(fragmentActivity)
                     goToSignIn()
                 } catch (e: SignOutError) {
                     Log.e("SignOutScreen", e.message, e)

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
@@ -1,15 +1,20 @@
 package uk.gov.onelogin.signOut.ui
 
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import uk.gov.onelogin.signOut.domain.SignOutUseCase
 
 @HiltViewModel
 class SignOutViewModel @Inject constructor(
     private val signOutUseCase: SignOutUseCase
 ) : ViewModel() {
-    fun signOut() {
-        signOutUseCase()
+    fun signOut(activityFragment: FragmentActivity) {
+        viewModelScope.launch {
+            signOutUseCase(activityFragment)
+        }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
@@ -14,7 +14,7 @@ class SignOutViewModel @Inject constructor(
 ) : ViewModel() {
     fun signOut(activityFragment: FragmentActivity) {
         viewModelScope.launch {
-            signOutUseCase(activityFragment)
+            signOutUseCase.invoke(activityFragment)
         }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCase.kt
@@ -1,0 +1,31 @@
+package uk.gov.onelogin.wallet
+
+import androidx.fragment.app.FragmentActivity
+import javax.inject.Inject
+import uk.gov.android.wallet.sdk.WalletSdk
+
+fun interface DeleteWalletDataUseCase {
+    suspend operator fun invoke(activityFragment: FragmentActivity)
+}
+
+@Suppress(
+    "TooGenericExceptionCaught",
+    "RethrowCaughtException",
+    "TooGenericExceptionThrown"
+)
+class DeleteWalletDataUseCaseImpl @Inject constructor(
+    private val walletSdk: WalletSdk
+) : DeleteWalletDataUseCase {
+    override suspend operator fun invoke(activityFragment: FragmentActivity) {
+        try {
+            val deleteResult = walletSdk.deleteWalletData(activityFragment)
+            if (!deleteResult) throw Exception(DELETE_WALLET_DATA_ERROR)
+        } catch (e: Throwable) {
+            throw e
+        }
+    }
+
+    companion object {
+        const val DELETE_WALLET_DATA_ERROR = "Failed deleting wallet data."
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCase.kt
+++ b/app/src/main/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCase.kt
@@ -5,25 +5,20 @@ import javax.inject.Inject
 import uk.gov.android.wallet.sdk.WalletSdk
 
 fun interface DeleteWalletDataUseCase {
-    suspend operator fun invoke(activityFragment: FragmentActivity)
+    suspend fun invoke(activityFragment: FragmentActivity)
 }
 
-@Suppress(
-    "TooGenericExceptionCaught",
-    "RethrowCaughtException",
-    "TooGenericExceptionThrown"
-)
 class DeleteWalletDataUseCaseImpl @Inject constructor(
     private val walletSdk: WalletSdk
 ) : DeleteWalletDataUseCase {
-    override suspend operator fun invoke(activityFragment: FragmentActivity) {
-        try {
-            val deleteResult = walletSdk.deleteWalletData(activityFragment)
-            if (!deleteResult) throw Exception(DELETE_WALLET_DATA_ERROR)
-        } catch (e: Throwable) {
-            throw e
-        }
+    override suspend fun invoke(activityFragment: FragmentActivity) {
+        val deleteResult = walletSdk.deleteWalletData(activityFragment)
+        if (!deleteResult) throw DeleteWalletDataError()
     }
+
+    data class DeleteWalletDataError(
+        override val message: String = DELETE_WALLET_DATA_ERROR
+    ) : Exception()
 
     companion object {
         const val DELETE_WALLET_DATA_ERROR = "Failed deleting wallet data."

--- a/app/src/main/java/uk/gov/onelogin/wallet/WalletModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/wallet/WalletModule.kt
@@ -8,22 +8,31 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.onelogin.R
+import uk.gov.android.wallet.core.deletedata.DeleteAllDataUseCase
 import uk.gov.android.wallet.sdk.WalletSdk
+import uk.gov.android.wallet.sdk.WalletSdkImpl
 
 @InstallIn(SingletonComponent::class)
 @Module
 object WalletModule {
     @Provides
     fun provideWalletSdk(
-        genericHttpClient: GenericHttpClient,
         @ApplicationContext
-        context: Context
+        context: Context,
+        genericHttpClient: GenericHttpClient,
+        deleteAllDataUseCase: DeleteAllDataUseCase
     ): WalletSdk {
         val config = WalletSdk.Configuration(
             clientId = context.resources.getString(R.string.stsClientId),
             authNetworkClient = genericHttpClient
         )
-        val client = WalletSdk.initialise(config)
-        return client
+        val walletSdk = WalletSdkImpl(deleteAllDataUseCase)
+        walletSdk.init(config)
+        return walletSdk
+    }
+
+    @Provides
+    fun provideDeleteWalletData(walletSdk: WalletSdk): DeleteWalletDataUseCase {
+        return DeleteWalletDataUseCaseImpl(walletSdk)
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
@@ -1,6 +1,10 @@
+@file:Suppress("TooGenericExceptionThrown")
+
 package uk.gov.onelogin.signOut.domain
 
+import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -9,24 +13,34 @@ import org.mockito.kotlin.whenever
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCaseImpl.Companion.DELETE_WALLET_DATA_ERROR
 
 class SignOutUseCaseTest {
+    private val activityFragment: FragmentActivity = mock()
     private val removeAllSecureStoreData: RemoveAllSecureStoreData = mock()
     private val removeTokenExpiry: RemoveTokenExpiry = mock()
     private val bioPrefHandler: BiometricPreferenceHandler = mock()
+    private val deleteWalletData: DeleteWalletDataUseCase = mock()
 
     private val sut =
-        SignOutUseCaseImpl(removeAllSecureStoreData, removeTokenExpiry, bioPrefHandler)
+        SignOutUseCaseImpl(
+            removeAllSecureStoreData,
+            removeTokenExpiry,
+            bioPrefHandler,
+            deleteWalletData
+        )
 
     @Test
-    operator fun invoke() {
+    operator fun invoke() = runBlocking {
         // WHEN we call sign out use case
-        sut.invoke()
+        sut.invoke(activityFragment)
 
         // THEN it clears all the required data
         verify(removeTokenExpiry).invoke()
         verify(removeAllSecureStoreData).invoke()
         verify(bioPrefHandler).clear()
+        verify(deleteWalletData).invoke(activityFragment)
     }
 
     @Test
@@ -35,8 +49,19 @@ class SignOutUseCaseTest {
             .thenThrow(RuntimeException("something went terribly bad"))
 
         val exception: SignOutError = Assertions.assertThrows(SignOutError::class.java) {
-            sut.invoke()
+            runBlocking { sut.invoke(activityFragment) }
         }
         assertTrue(exception.error.message!!.contains("something went terribly bad"))
+    }
+
+    @Test
+    fun `sign out delete wallet data error`() = runBlocking {
+        whenever(deleteWalletData.invoke(activityFragment)).then {
+            throw Exception(DELETE_WALLET_DATA_ERROR)
+        }
+        val exception: SignOutError = Assertions.assertThrows(SignOutError::class.java) {
+            runBlocking { sut.invoke(activityFragment) }
+        }
+        assertTrue(exception.error.message!!.contains(DELETE_WALLET_DATA_ERROR))
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/signOut/domain/SignOutUseCaseTest.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooGenericExceptionThrown")
-
 package uk.gov.onelogin.signOut.domain
 
 import androidx.fragment.app.FragmentActivity
@@ -14,6 +12,7 @@ import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 import uk.gov.onelogin.wallet.DeleteWalletDataUseCase
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCaseImpl
 import uk.gov.onelogin.wallet.DeleteWalletDataUseCaseImpl.Companion.DELETE_WALLET_DATA_ERROR
 
 class SignOutUseCaseTest {
@@ -57,7 +56,7 @@ class SignOutUseCaseTest {
     @Test
     fun `sign out delete wallet data error`() = runBlocking {
         whenever(deleteWalletData.invoke(activityFragment)).then {
-            throw Exception(DELETE_WALLET_DATA_ERROR)
+            throw DeleteWalletDataUseCaseImpl.DeleteWalletDataError()
         }
         val exception: SignOutError = Assertions.assertThrows(SignOutError::class.java) {
             runBlocking { sut.invoke(activityFragment) }

--- a/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
@@ -22,7 +22,7 @@ class DeleteWalletDataUseCaseTest {
     @Test
     fun `delete wallet data success`() = runBlocking {
         whenever(walletSdk.deleteWalletData(any())).thenReturn(true)
-        val result = sut(activityFragment)
+        val result = sut.invoke(activityFragment)
         assertEquals(Unit, result)
     }
 

--- a/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.onelogin.wallet
+
+import androidx.fragment.app.FragmentActivity
+import io.ktor.util.reflect.instanceOf
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.android.wallet.sdk.WalletSdk
+import uk.gov.android.wallet.sdk.WalletSdkImpl
+import uk.gov.onelogin.wallet.DeleteWalletDataUseCaseImpl.Companion.DELETE_WALLET_DATA_ERROR
+
+class DeleteWalletDataUseCaseTest {
+    private val walletSdk: WalletSdkImpl = mock()
+    private val activityFragment: FragmentActivity = mock()
+    private val sut = DeleteWalletDataUseCaseImpl(walletSdk)
+
+    @Test
+    fun `delete wallet data success`() = runBlocking {
+        whenever(walletSdk.deleteWalletData(any())).thenReturn(true)
+        val result = sut(activityFragment)
+        assertEquals(Unit, result)
+    }
+
+    @Test
+    fun `delete wallet data error`() = runBlocking {
+        whenever(walletSdk.deleteWalletData(any())).thenReturn(false)
+        val result = Assertions.assertThrows(Exception::class.java) {
+            runBlocking { sut.invoke(activityFragment) }
+        }
+        assertTrue(result.message!!.contains(DELETE_WALLET_DATA_ERROR))
+    }
+
+    @Test
+    fun `walled sdk init error`() = runBlocking {
+        whenever(walletSdk.deleteWalletData(any())).then {
+            throw WalletSdk.WalletSdkError.SdkNotInitialised
+        }
+        val result = Assertions.assertThrows(
+            WalletSdk.WalletSdkError.SdkNotInitialised::class.java
+        ) {
+            runBlocking { sut.invoke(activityFragment) }
+        }
+        assertTrue(result.instanceOf(WalletSdk.WalletSdkError.SdkNotInitialised::class))
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/wallet/DeleteWalletDataUseCaseTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.wallet
 
 import androidx.fragment.app.FragmentActivity
-import io.ktor.util.reflect.instanceOf
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
@@ -29,22 +28,23 @@ class DeleteWalletDataUseCaseTest {
     @Test
     fun `delete wallet data error`() = runBlocking {
         whenever(walletSdk.deleteWalletData(any())).thenReturn(false)
-        val result = Assertions.assertThrows(Exception::class.java) {
+        val result = Assertions.assertThrows(
+            DeleteWalletDataUseCaseImpl.DeleteWalletDataError::class.java
+        ) {
             runBlocking { sut.invoke(activityFragment) }
         }
-        assertTrue(result.message!!.contains(DELETE_WALLET_DATA_ERROR))
+        assertTrue(result.message.contains(DELETE_WALLET_DATA_ERROR))
     }
 
     @Test
-    fun `walled sdk init error`() = runBlocking {
+    fun `walled sdk init error`(): Unit = runBlocking {
         whenever(walletSdk.deleteWalletData(any())).then {
             throw WalletSdk.WalletSdkError.SdkNotInitialised
         }
-        val result = Assertions.assertThrows(
+        Assertions.assertThrows(
             WalletSdk.WalletSdkError.SdkNotInitialised::class.java
         ) {
             runBlocking { sut.invoke(activityFragment) }
         }
-        assertTrue(result.instanceOf(WalletSdk.WalletSdkError.SdkNotInitialised::class))
     }
 }

--- a/buildLogic/plugins/src/main/kotlin/uk.gov.onelogin.jvm-toolchains.gradle.kts
+++ b/buildLogic/plugins/src/main/kotlin/uk.gov.onelogin.jvm-toolchains.gradle.kts
@@ -1,7 +1,7 @@
 import com.android.build.gradle.BaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
-val jvmVersion by extra(11)
+val jvmVersion by extra(17)
 
 plugins {
     id("kotlin-android")

--- a/features/build.gradle.kts
+++ b/features/build.gradle.kts
@@ -64,11 +64,11 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
 
     testOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ org-sonarqube = { id = "org.sonarqube", version.ref = "sonarqube-gradle" }
 
 [versions]
 jose4j = "0.9.6"
-kotlin = "2.0.0"
+kotlin = "2.0.10"
 agp = "8.5.2"
 core-ktx = "1.13.1"
 androidx-test-ext-junit = "1.1.5"
@@ -44,15 +44,14 @@ sonarqube-gradle = "5.0.0.4638" # https://github.com/SonarSource/sonar-scanner-g
 googleServices = "4.4.2"
 firebaseBom = "33.2.0"
 classgraph = "4.8.174"
-govuk-ui = "4.4.1"
+govuk-ui = "5.4.2"
 compose-runtime = "1.6.8"
-wallet = "1.28.0"
+wallet = "1.29.0"
 
 [libraries]
 wallet-sdk = { module = "uk.gov.android.wallet:wallet_sdk", version.ref = "wallet" }
 runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose-runtime" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
-components = "uk.gov.android:components:4.4.1"
 test-core-ktx = { group = "androidx.test", name = "core-ktx", version = "1.5.0" }
 gson = { group = "com.google.code.gson", name = "gson", version = "2.11.0" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltPlugin" }
@@ -69,16 +68,17 @@ ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version = "2.
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "5.4.0" }
 mockito-android = { group = "org.mockito", name = "mockito-android", version = "5.13.0" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version = "2.7.7" }
-pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 slf4j-api = { group = "org.slf4j", name = "slf4j-api", version = "2.0.16" }
+pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
+components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version = "2.3.0" }
 authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.6.2" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
-network = { group = "uk.gov.android", name = "network", version = "0.2.2" }
+network = { group = "uk.gov.android", name = "network", version = "0.2.7" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "andoridxBrowser" }


### PR DESCRIPTION
**Ticket Link:** 
[DCMAW-9185](https://govukverify.atlassian.net/browse/DCMAW-9185)

**Description Of Changes:**
 - update java version used to v17
- update walletSdk version - update other dependencies to newer versions to be compatible with the wallet sdk
- update all use cases dependent on deleteWalletData
- update Wallet module: new wallet impl and delete data use case
- amend/ write tests accordingly

**Evidence:**
AC3 cannot de demo-ed - there is a unit test for it.

AC1:
Scenario 1: Credentials deleted successfully when Wallet API is called
GIVEN I am a user on the strategic app
AND I’m on the Sign out confirmation page
WHEN I tap the 'Sign out and delete app data' CTA
THEN Wallet credential deletion API is called
AND my Wallet credentials are deleted

https://github.com/user-attachments/assets/5816d597-be29-48f7-91b3-99aa3ac5dd3f

AC2:
Scenario 2 - User treated as ‘First time user’ when they return to the app (goes to Sign in page)
GIVEN I’m a logged in user on the Strategic app
AND I have credentials stored in my Wallet
AND I sign out using the functionality on the Profile tab
AND my sign out is successful
AND I leave the app
WHEN I return to the app
THEN I’m directed down the ‘First time user’ flow
AND I cannot see any Wallet credentials upon successful login

https://github.com/user-attachments/assets/5c816e88-4a37-4afe-8657-b244d79c13fa



**Definition Of Done Checklist:**

- [x] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [x] Relevant integration and end-to-end tests are written
- [x] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [x] Sonar coverage gates met 
- [ ] If feature flagged, Feature is enabled in staging and manually tested to ensure integration

Resolves: DCMAW-9185

[DCMAW-9185]: https://govukverify.atlassian.net/browse/DCMAW-9185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ