### PR TITLE
Feat: DCMAW-9635

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModelTest.kt
@@ -1,0 +1,72 @@
+package uk.gov.onelogin.signOut.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import uk.gov.android.onelogin.R
+import uk.gov.logging.api.analytics.extensions.domain
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+class SignedOutInfoAnalyticsViewModelTest {
+    private lateinit var domain: String
+    private lateinit var buttonText: String
+    private lateinit var name: String
+    private lateinit var id: String
+    private lateinit var logger: AnalyticsLogger
+    private lateinit var requiredParameters: RequiredParameters
+    private lateinit var viewModel: SignedOutInfoAnalyticsViewModel
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        logger = mock()
+        requiredParameters = RequiredParameters(
+            taxonomyLevel2 = TaxonomyLevel2.LOGIN,
+            taxonomyLevel3 = TaxonomyLevel3.RE_AUTH
+        )
+        domain = context.getEnglishString(R.string.openIdConnectBaseUrl, "").domain
+        buttonText = context.getEnglishString(R.string.app_SignInWithGovUKOneLoginButton)
+        name = context.getEnglishString(R.string.app_youveBeenSignedOutTitle)
+        id = context.getEnglishString(R.string.signed_out_info_page_id)
+        viewModel = SignedOutInfoAnalyticsViewModel(context, logger)
+    }
+
+    @Test
+    fun trackSignOutLogsTrackEventLink() {
+        // Given a TrackEvent.Link
+        val event = TrackEvent.Link(
+            isExternal = false,
+            domain = domain,
+            text = buttonText,
+            params = requiredParameters
+        )
+        // When tracking re-auth
+        viewModel.trackReAuth()
+        // Then log a TrackEvent to the AnalyticsLogger
+        verify(logger).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun trackSignOutViewLogsViewEventScreen() {
+        // Given a ViewEvent.Screen
+        val event = ViewEvent.Screen(
+            name = name,
+            id = id,
+            params = requiredParameters
+        )
+        // When tracking the signed out info screen view
+        viewModel.trackSignOutInfoView()
+        // Then log a ScreenView to the AnalyticsLogger
+        verify(logger).logEventV3Dot1(event)
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
@@ -347,4 +347,11 @@ class SignedOutInfoScreenTest : TestCase() {
             value = id
         )
     }
+
+    @Test
+    fun previewTest() {
+        composeTestRule.setContent {
+            SignedOutInfoPreview()
+        }
+    }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.onelogin.signOut.ui
 
+import android.content.Context
 import android.net.Uri
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
@@ -27,7 +29,10 @@ import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.network.useragent.UserAgentGenerator
 import uk.gov.android.onelogin.R
 import uk.gov.android.securestore.SecureStore
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.TestCase
+import uk.gov.onelogin.core.analytics.AnalyticsModule
 import uk.gov.onelogin.features.FeaturesModule
 import uk.gov.onelogin.features.StsFeatureFlag
 import uk.gov.onelogin.login.authentication.LoginSessionModule
@@ -46,7 +51,8 @@ import uk.gov.onelogin.ui.error.ErrorRoutes
     FeaturesModule::class,
     NetworkModule::class,
     NavigatorModule::class,
-    SignOutModule::class
+    SignOutModule::class,
+    AnalyticsModule::class
 )
 class SignedOutInfoScreenTest : TestCase() {
     @BindValue
@@ -69,6 +75,9 @@ class SignedOutInfoScreenTest : TestCase() {
 
     @BindValue
     val mockSignOutUseCase: SignOutUseCase = mock()
+
+    @BindValue
+    val analytics: AnalyticsLogger = mock()
 
     @Inject
     @Named("Open")
@@ -292,6 +301,29 @@ class SignedOutInfoScreenTest : TestCase() {
         whenWeClickSignIn()
 
         itOpensErrorScreen()
+    }
+
+    @Test
+    fun screenViewAnalyticsLogOnResume() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val event = SignedOutInfoAnalyticsViewModel.makeSignedOutInfoViewEvent(context)
+        composeTestRule.setContent {
+            SignedOutInfoScreen()
+        }
+
+        verify(analytics).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun reAuthAnalyticsLogOnSignInButton() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val event = SignedOutInfoAnalyticsViewModel.makeReAuthEvent(context)
+        whenever(onlineChecker.isOnline()).thenReturn(true)
+        composeTestRule.setContent {
+            SignedOutInfoScreen()
+        }
+        whenWeClickSignIn()
+        verify(analytics).logEventV3Dot1(event)
     }
 
     private fun whenWeClickSignIn() {

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModel.kt
@@ -1,0 +1,59 @@
+package uk.gov.onelogin.signOut.ui
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import uk.gov.android.onelogin.R
+import uk.gov.logging.api.analytics.extensions.domain
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+@HiltViewModel
+class SignedOutInfoAnalyticsViewModel @Inject constructor(
+    @ApplicationContext context: Context,
+    private val analyticsLogger: AnalyticsLogger
+) : ViewModel() {
+    private val reAuthEvent = makeReAuthEvent(context)
+    private val signedOutInfoViewEvent = makeSignedOutInfoViewEvent(context)
+
+    fun trackReAuth() {
+        analyticsLogger.logEventV3Dot1(reAuthEvent)
+    }
+
+    fun trackSignOutInfoView() {
+        analyticsLogger.logEventV3Dot1(signedOutInfoViewEvent)
+    }
+
+    companion object {
+        private fun makeReAuthEvent(context: Context) = with(context) {
+            TrackEvent.Link(
+                isExternal = false,
+                domain = getEnglishString(R.string.openIdConnectBaseUrl, "").domain,
+                text = getEnglishString(R.string.app_SignInWithGovUKOneLoginButton),
+                params = RequiredParameters(
+                    taxonomyLevel2 = TaxonomyLevel2.LOGIN,
+                    taxonomyLevel3 = TaxonomyLevel3.RE_AUTH
+                )
+            )
+        }
+
+        private fun makeSignedOutInfoViewEvent(context: Context) = with(context) {
+            ViewEvent.Screen(
+                name = getEnglishString(R.string.app_youveBeenSignedOutTitle),
+                id = getEnglishString(R.string.signed_out_info_page_id),
+                params = RequiredParameters(
+                    taxonomyLevel2 = TaxonomyLevel2.LOGIN,
+                    taxonomyLevel3 = TaxonomyLevel3.RE_AUTH
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoAnalyticsViewModel.kt
@@ -33,7 +33,7 @@ class SignedOutInfoAnalyticsViewModel @Inject constructor(
     }
 
     companion object {
-        private fun makeReAuthEvent(context: Context) = with(context) {
+        fun makeReAuthEvent(context: Context) = with(context) {
             TrackEvent.Link(
                 isExternal = false,
                 domain = getEnglishString(R.string.openIdConnectBaseUrl, "").domain,
@@ -45,7 +45,7 @@ class SignedOutInfoAnalyticsViewModel @Inject constructor(
             )
         }
 
-        private fun makeSignedOutInfoViewEvent(context: Context) = with(context) {
+        fun makeSignedOutInfoViewEvent(context: Context) = with(context) {
             ViewEvent.Screen(
                 name = getEnglishString(R.string.app_youveBeenSignedOutTitle),
                 id = getEnglishString(R.string.signed_out_info_page_id),

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
@@ -10,12 +10,16 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.pages.LandingPage
 import uk.gov.android.ui.pages.LandingPageParameters
+import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.smallPadding
 import uk.gov.onelogin.login.ui.welcome.WelcomeScreenViewModel
 
@@ -52,31 +56,14 @@ fun SignedOutInfoScreen(
             activity
         )
     }
-
-    LandingPage(
-        landingPageParameters = LandingPageParameters(
-            title = R.string.app_youveBeenSignedOutTitle,
-            titleBottomPadding = smallPadding,
-            content = listOf(
-                GdsContentText.GdsContentTextString(
-                    intArrayOf(R.string.app_youveBeenSignedOutBody1)
-                ),
-                GdsContentText.GdsContentTextString(
-                    intArrayOf(R.string.app_youveBeenSignedOutBody2)
-                )
-            ),
-            contentInternalPadding = PaddingValues(bottom = smallPadding),
-            primaryButtonText = R.string.app_SignInWithGovUKOneLoginButton,
-            onPrimary = {
-                handleLogin(
-                    loginViewModel,
-                    signOutViewModel,
-                    launcher,
-                    activity
-                )
-            }
+    SignedOutInfoBody {
+        handleLogin(
+            loginViewModel,
+            signOutViewModel,
+            launcher,
+            activity
         )
-    )
+    }
 }
 
 private fun handleLogin(
@@ -91,5 +78,38 @@ private fun handleLogin(
         }
     } else {
         loginViewModel.navigateToOfflineError()
+    }
+}
+
+@Composable
+internal fun SignedOutInfoBody(
+    onPrimary: () -> Unit
+) {
+    LandingPage(
+        landingPageParameters = LandingPageParameters(
+            title = R.string.app_youveBeenSignedOutTitle,
+            titleBottomPadding = smallPadding,
+            content = listOf(
+                GdsContentText.GdsContentTextString(
+                    intArrayOf(R.string.app_youveBeenSignedOutBody1)
+                ),
+                GdsContentText.GdsContentTextString(
+                    intArrayOf(R.string.app_youveBeenSignedOutBody2)
+                )
+            ),
+            contentInternalPadding = PaddingValues(bottom = smallPadding),
+            primaryButtonText = R.string.app_SignInWithGovUKOneLoginButton,
+            onPrimary = onPrimary
+        )
+    )
+}
+
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
+@Composable
+internal fun SignedOutInfoPreview() {
+    GdsTheme {
+        SignedOutInfoBody {}
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.pages.LandingPage
@@ -29,6 +31,7 @@ fun SignedOutInfoScreen(
     signOutViewModel: SignedOutInfoViewModel = hiltViewModel(),
     shouldTryAgain: () -> Boolean = { false }
 ) {
+    val analytics: SignedOutInfoAnalyticsViewModel = hiltViewModel()
     val activity = LocalContext.current as FragmentActivity
     val launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -57,6 +60,7 @@ fun SignedOutInfoScreen(
         )
     }
     SignedOutInfoBody {
+        analytics.trackReAuth()
         handleLogin(
             loginViewModel,
             signOutViewModel,
@@ -64,6 +68,7 @@ fun SignedOutInfoScreen(
             activity
         )
     }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { analytics.trackSignOutInfoView() }
 }
 
 private fun handleLogin(

--- a/app/src/main/res/values/screen_ids.xml
+++ b/app/src/main/res/values/screen_ids.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="sign_in_page_id" translatable="false">30a6b339-75a8-44a2-a79a-e108546419bf</string>
+    <string name="signed_out_info_page_id" translatable="false">cfc50baa-4b56-4170-9707-cd05b60b6658</string>
 </resources>


### PR DESCRIPTION
# DCMAW-9635: GA4 schema on the Signed Out Info page

[Ticket DCMAW-9635](https://govukverify.atlassian.net/browse/DCMAW-9635)

## Description of changes:

- Built on top of DCMAW-8381, so only the last 6 commits are actually this ticket until 8381 is merged
- Adds Preview to SignedOutInfo
- Adds Analytics to SignedOutInfoScreen

## Evidence of the change

User has opted-in to analytics

AC1a: trackScreen analytics
GIVEN I have previously opted in to analytics
WHEN I land on the ‘You’ve been signed out' page
THEN the trackScreen analytics defined in the OpenAPI spec will be sent to GA4
AND the firebase Screen ID [screenView] is set to cfc50baa-4b56-4170-9707-cd05b60b6658

![DCMAW-9635-ScreenView-1](https://github.com/user-attachments/assets/1f5b2e7b-d78f-431b-b652-9bd0bd0d2c03)
![DCMAW-9635-ScreenView-2](https://github.com/user-attachments/assets/192b3969-599a-4be6-84a0-2afeeaa337b4)

AC2a: trackEventLink analytics ('Sign in with GOV.UK One Login' link to authentication webview)
GIVEN I have previously opted in to analytics
AND I’m on the ‘You’ve been signed out' page
WHEN I click the ‘Sign in with GOV.UK One Login’ CTA
THEN the trackEventLink analytics defined in the OpenAPI spec will be sent to GA4

This should be trackEventLink, because this button links out to the WebView

![DCMAW-9635-Navigation-1](https://github.com/user-attachments/assets/2be5f102-9f98-4952-8d3b-24600f524cf3)
![DCMAW-9635-Navigation-2](https://github.com/user-attachments/assets/8ba971d8-c147-4def-aae8-025b1ce3378c)

User has not opted-in to analytics

AC1b: trackScreen analytics
GIVEN I have previously opted in to analytics
WHEN I land on the ‘You’ve been signed out' page
THEN no trackScreen data is sent to GA4

AC2b: trackEventLink analytics (‘Sign in with GOV.UK One Login’ CTA link to authentication webview)
GIVEN I have previously opted in to analytics
AND I’m on the ‘You’ve been signed out' page
WHEN I click the ‘Sign in with GOV.UK One Login’ CTA
THEN no data is sent to GA4

![DCMAW-9635-Disabled](https://github.com/user-attachments/assets/d084ea87-0e67-42c5-868e-61433db04c3c)

Analytics always sent in English

AC3: Welsh language analytics
GIVEN user is on the ‘You’ve been signed out' page
WHEN the language parameter is set to CY
THEN any analytics sent are still sent in English

![DCMAW-9635-Navigation-Welsh-1](https://github.com/user-attachments/assets/c7e20173-822b-47f2-bd28-fc8583f940c3)
![DCMAW-9635-Navigation-Welsh-2](https://github.com/user-attachments/assets/8c8be97b-c4da-4a26-bcf3-b4c4cb98fe62)
![DCMAW-9635-ScreenView-Welsh-1](https://github.com/user-attachments/assets/46239488-af0f-4638-a024-ce35fb60bd7c)
![DCMAW-9635-ScreenView-Welsh-2](https://github.com/user-attachments/assets/22a1718e-9520-4b5e-bb83-1f8ec560a7ac)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-onelogin-app
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing