### PR TITLE
Feat: DCMAW 9613

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenTest.kt
@@ -35,6 +35,8 @@ import uk.gov.onelogin.navigation.Navigator
 import uk.gov.onelogin.navigation.NavigatorModule
 import uk.gov.onelogin.optin.BinderModule
 import uk.gov.onelogin.optin.domain.repository.OptInRepository
+import uk.gov.onelogin.optin.domain.source.OptInLocalSource
+import uk.gov.onelogin.optin.domain.source.OptInRemoteSource
 import uk.gov.onelogin.optin.ui.NOTICE_TAG
 
 @HiltAndroidTest
@@ -65,6 +67,12 @@ class SplashScreenTest : TestCase() {
 
     @BindValue
     val analyticsRepo: OptInRepository = mock()
+
+    @BindValue
+    val optInLocalSource: OptInLocalSource = mock()
+
+    @BindValue
+    val optInRemoteSource: OptInRemoteSource = mock()
 
     private lateinit var splashIcon: SemanticsMatcher
     private lateinit var unlockButton: SemanticsMatcher

--- a/app/src/androidTest/java/uk/gov/onelogin/navigation/NavControllerExtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/navigation/NavControllerExtTest.kt
@@ -1,0 +1,58 @@
+package uk.gov.onelogin.navigation
+
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.NavHost
+import androidx.navigation.testing.TestNavHostController
+import dagger.hilt.android.testing.HiltAndroidTest
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import uk.gov.onelogin.TestCase
+import uk.gov.onelogin.login.LoginGraphObject.loginGraph
+import uk.gov.onelogin.login.LoginRoutes
+
+@HiltAndroidTest
+class NavControllerExtTest : TestCase() {
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        composeTestRule.setContent {
+            navController = TestNavHostController(context)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            NavHost(
+                navController = navController,
+                startDestination = LoginRoutes.Root.getRoute()
+            ) {
+                loginGraph(navController)
+            }
+        }
+    }
+
+    @Test
+    fun hasPreviousBackStackFalseInitially() {
+        assertFalse(navController.hasPreviousBackStack())
+    }
+
+    @Test
+    fun hasPreviousBackStackTrueForAddedBackStack() {
+        composeTestRule.runOnUiThread {
+            navController.setCurrentDestination(LoginRoutes.BioOptIn.getRoute())
+        }
+        assertTrue(navController.hasPreviousBackStack())
+    }
+
+    @Test
+    fun closeAppPopsAllBackStack() {
+        composeTestRule.runOnUiThread {
+            // Fill up backstack
+            navController.setCurrentDestination(LoginRoutes.BioOptIn.getRoute())
+            navController.setCurrentDestination(LoginRoutes.Loading.getRoute())
+            navController.setCurrentDestination(LoginRoutes.SignInError.getRoute())
+            navController.setCurrentDestination(LoginRoutes.AnalyticsOptIn.getRoute())
+            navController.closeApp()
+        }
+        assertFalse(navController.hasPreviousBackStack())
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.ui.update
+package uk.gov.onelogin.ui.error.update
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
@@ -16,6 +16,7 @@ import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.logging.api.v3dot1.model.ViewEvent
+import uk.gov.onelogin.appinfo.AppInfoUtils
 
 class UpdateRequiredAnalyticsViewModelTest {
     private lateinit var domain: String
@@ -35,7 +36,7 @@ class UpdateRequiredAnalyticsViewModelTest {
             taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,
             taxonomyLevel3 = TaxonomyLevel3.UNDEFINED
         )
-        domain = context.getEnglishString(R.string.openIdConnectBaseUrl, "").domain
+        domain = AppInfoUtils.GOOGLE_PLAY_URL.domain
         buttonText = context.getEnglishString(R.string.app_updateAppButton)
         name = context.getEnglishString(R.string.app_updateApp_Title)
         id = context.getEnglishString(R.string.update_required_page_id)
@@ -44,7 +45,7 @@ class UpdateRequiredAnalyticsViewModelTest {
     }
 
     @Test
-    fun trackSignOutLogsTrackEventLink() {
+    fun trackAppUpdateLogsTrackEventLink() {
         // Given a TrackEvent.Link
         val event = TrackEvent.Link(
             isExternal = true,

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModelTest.kt
@@ -1,0 +1,87 @@
+package uk.gov.onelogin.ui.update
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import uk.gov.android.onelogin.R
+import uk.gov.logging.api.analytics.extensions.domain
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+class UpdateRequiredAnalyticsViewModelTest {
+    private lateinit var domain: String
+    private lateinit var buttonText: String
+    private lateinit var name: String
+    private lateinit var id: String
+    private lateinit var iconText: String
+    private lateinit var logger: AnalyticsLogger
+    private lateinit var requiredParameters: RequiredParameters
+    private lateinit var viewModel: UpdateRequiredAnalyticsViewModel
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        logger = mock()
+        requiredParameters = RequiredParameters(
+            taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,
+            taxonomyLevel3 = TaxonomyLevel3.UNDEFINED
+        )
+        domain = context.getEnglishString(R.string.openIdConnectBaseUrl, "").domain
+        buttonText = context.getEnglishString(R.string.app_updateAppButton)
+        name = context.getEnglishString(R.string.app_updateApp_Title)
+        id = context.getEnglishString(R.string.update_required_page_id)
+        iconText = context.getEnglishString(R.string.system_bottomNavigation_backButton)
+        viewModel = UpdateRequiredAnalyticsViewModel(context, logger)
+    }
+
+    @Test
+    fun trackSignOutLogsTrackEventLink() {
+        // Given a TrackEvent.Link
+        val event = TrackEvent.Link(
+            isExternal = true,
+            domain = domain,
+            text = buttonText,
+            params = requiredParameters
+        )
+        // When tracking an app update
+        viewModel.trackAppUpdate()
+        // Then log a TrackEvent to the AnalyticsLogger
+        verify(logger).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun trackSignOutViewLogsScreenView() {
+        // Given a ViewEvent.Screen
+        val event = ViewEvent.Screen(
+            name = name,
+            id = id,
+            params = requiredParameters
+        )
+        // When tracking the update required screen view
+        viewModel.trackUpdateRequiredView()
+        // Then log a ScreenView to the AnalyticsLogger
+        verify(logger).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun trackBackButtonLogsTrackEventIcon() {
+        // Given a TrackEvent.Icon
+        val event = TrackEvent.Icon(
+            text = iconText,
+            params = requiredParameters
+        )
+        // When tracking the hardware back button
+        viewModel.trackBackButton()
+        // Then log a TrackEvent to the AnalyticsLogger
+        verify(logger).logEventV3Dot1(event)
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredBodyTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredBodyTest.kt
@@ -1,0 +1,66 @@
+package uk.gov.onelogin.ui.error.update
+
+import android.content.Context
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import uk.gov.android.onelogin.R
+
+class UpdateRequiredBodyTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var title: SemanticsMatcher
+    private lateinit var body1: SemanticsMatcher
+    private lateinit var body2: SemanticsMatcher
+    private lateinit var primaryButton: SemanticsMatcher
+    private lateinit var icon: SemanticsMatcher
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+
+        title = hasText(context.getString(R.string.app_updateApp_Title))
+        body1 = hasText(context.getString(R.string.app_updateAppBody1))
+        body2 = hasText(context.getString(R.string.app_updateAppBody2))
+        primaryButton = hasText(context.getString(R.string.app_updateAppButton))
+        icon = hasContentDescription(context.getString(R.string.app_updateApp_ContentDescription))
+    }
+
+    @Test
+    fun verifyComponents() {
+        // Given
+        composeTestRule.setContent {
+            UpdateRequiredBody {}
+        }
+        // Then
+        composeTestRule.onNode(title).assertIsDisplayed()
+        composeTestRule.onNode(body1).assertIsDisplayed()
+        composeTestRule.onNode(body2).assertIsDisplayed()
+        composeTestRule.onNode(primaryButton).assertIsDisplayed()
+        composeTestRule.onNode(icon).assertIsDisplayed()
+    }
+
+    @Test
+    fun onUpdateApp() {
+        // Given the UpdateRequiredBody Composable
+        var actual = false
+        composeTestRule.setContent {
+            UpdateRequiredBody(
+                onPrimary = { actual = true }
+            )
+        }
+        // When clicking the `primaryButton`
+        composeTestRule.onNode(primaryButton).performClick()
+        // Then onUpdateApp() is called and the variable is true
+        assertEquals(true, actual)
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreenTest.kt
@@ -86,10 +86,7 @@ class UpdateRequiredErrorScreenTest : TestCase() {
             UpdateRequiredScreen()
         }
         intending(hasData(AppInfoUtils.GOOGLE_PLAY_URL)).respondWith(result)
-        composeTestRule.apply {
-            onNodeWithText(resources.getString(R.string.app_updateAppButton)).performClick()
-        }
-
+        composeTestRule.onNode(primaryButton).performClick()
         intended(hasAction(Intent.ACTION_VIEW))
         intended(hasData(Uri.parse(AppInfoUtils.GOOGLE_PLAY_URL)))
     }
@@ -110,7 +107,7 @@ class UpdateRequiredErrorScreenTest : TestCase() {
             UpdateRequiredScreen()
         }
         val event = UpdateRequiredAnalyticsViewModel.makeUpdateEvent(context)
-
+        intending(hasData(AppInfoUtils.GOOGLE_PLAY_URL)).respondWith(result)
         composeTestRule.onNode(primaryButton).performClick()
         verify(analytics).logEventV3Dot1(event)
     }

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreenTest.kt
@@ -4,35 +4,51 @@ import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.NoActivityResumedException
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.UninstallModules
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import uk.gov.android.onelogin.R
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.TestCase
 import uk.gov.onelogin.appinfo.AppInfoUtils
+import uk.gov.onelogin.core.analytics.AnalyticsModule
 
 @HiltAndroidTest
+@UninstallModules(
+    AnalyticsModule::class
+)
 class UpdateRequiredErrorScreenTest : TestCase() {
     private val intent = Intent()
     private val result = Instrumentation.ActivityResult(Activity.RESULT_OK, intent)
+    private lateinit var primaryButton: SemanticsMatcher
+
+    @BindValue
+    val analytics: AnalyticsLogger = mock()
 
     @Before
     fun setup() {
         hiltRule.inject()
         Intents.init()
-        composeTestRule.setContent {
-            UpdateRequiredScreen()
-        }
+        primaryButton = hasText(context.getString(R.string.app_updateAppButton))
     }
 
     @After
@@ -42,6 +58,9 @@ class UpdateRequiredErrorScreenTest : TestCase() {
 
     @Test
     fun verifyScreenDisplayed() {
+        composeTestRule.setContent {
+            UpdateRequiredScreen()
+        }
         composeTestRule.apply {
             onNodeWithContentDescription(
                 resources.getString(R.string.app_updateApp_ContentDescription)
@@ -63,6 +82,9 @@ class UpdateRequiredErrorScreenTest : TestCase() {
 
     @Test
     fun verifyIntent() {
+        composeTestRule.setContent {
+            UpdateRequiredScreen()
+        }
         intending(hasData(AppInfoUtils.GOOGLE_PLAY_URL)).respondWith(result)
         composeTestRule.apply {
             onNodeWithText(resources.getString(R.string.app_updateAppButton)).performClick()
@@ -70,5 +92,48 @@ class UpdateRequiredErrorScreenTest : TestCase() {
 
         intended(hasAction(Intent.ACTION_VIEW))
         intended(hasData(Uri.parse(AppInfoUtils.GOOGLE_PLAY_URL)))
+    }
+
+    @Test
+    fun screenViewAnalyticsLogOnResume() {
+        composeTestRule.setContent {
+            UpdateRequiredScreen()
+        }
+        val event = UpdateRequiredAnalyticsViewModel.makeUpdateRequiredViewEvent(context)
+
+        verify(analytics).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun updateAnalyticsLogOnUpdateAppButton() {
+        composeTestRule.setContent {
+            UpdateRequiredScreen()
+        }
+        val event = UpdateRequiredAnalyticsViewModel.makeUpdateEvent(context)
+
+        composeTestRule.onNode(primaryButton).performClick()
+        verify(analytics).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun iconAnalyticsLogOnBackButton() {
+        composeTestRule.setContent {
+            UpdateRequiredScreen()
+        }
+        val event = UpdateRequiredAnalyticsViewModel.makeBackEvent(context)
+        composeTestRule.waitForIdle()
+        try {
+            Espresso.pressBack()
+        } catch (_: NoActivityResumedException) {
+        }
+
+        verify(analytics).logEventV3Dot1(event)
+    }
+
+    @Test
+    fun previewTest() {
+        composeTestRule.setContent {
+            UpdateRequiredPreview()
+        }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -3,17 +3,21 @@ package uk.gov.onelogin
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.login.biooptin.BiometricPreference
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.navigation.Navigator
+import uk.gov.onelogin.optin.domain.repository.AnalyticsOptInRepository
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.usecases.AutoInitialiseSecureStore
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
+    private val analyticsOptInRepo: AnalyticsOptInRepository,
     private val bioPrefHandler: BiometricPreferenceHandler,
     private val tokenRepository: TokenRepository,
     private val navigator: Navigator,
@@ -22,6 +26,13 @@ class MainActivityViewModel @Inject constructor(
 
     init {
         autoInitialiseSecureStore()
+    }
+
+    override fun onStart(owner: LifecycleOwner) {
+        super.onStart(owner)
+        viewModelScope.launch {
+            analyticsOptInRepo.synchronise()
+        }
     }
 
     override fun onPause(owner: LifecycleOwner) {

--- a/app/src/main/java/uk/gov/onelogin/navigation/NavControllerExt.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/NavControllerExt.kt
@@ -1,8 +1,16 @@
 package uk.gov.onelogin.navigation
 
+import android.app.Activity
 import androidx.navigation.NavHostController
 
 fun NavHostController.hasPreviousBackStack() = this.previousBackStackEntry != null
 
 fun NavHostController.navigateSingleTopTo(route: String) =
     this.navigate(route) { launchSingleTop = true }
+
+fun NavHostController.closeApp() {
+    while (hasPreviousBackStack()) {
+        popBackStack()
+    }
+    (context as? Activity)?.finish()
+}

--- a/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
@@ -1,0 +1,74 @@
+package uk.gov.onelogin.ui.update
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import uk.gov.android.onelogin.R
+import uk.gov.logging.api.analytics.extensions.domain
+import uk.gov.logging.api.analytics.extensions.getEnglishString
+import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
+import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.api.v3dot1.model.RequiredParameters
+import uk.gov.logging.api.v3dot1.model.TrackEvent
+import uk.gov.logging.api.v3dot1.model.ViewEvent
+
+@HiltViewModel
+class UpdateRequiredAnalyticsViewModel @Inject constructor(
+    @ApplicationContext context: Context,
+    private val analyticsLogger: AnalyticsLogger
+) : ViewModel() {
+    private val updateEvent = makeUpdateEvent(context)
+    private val updateRequiredViewEvent = makeUpdateRequiredViewEvent(context)
+    private val backEvent = makeBackEvent(context)
+
+    fun trackAppUpdate() {
+        analyticsLogger.logEventV3Dot1(updateEvent)
+    }
+
+    fun trackUpdateRequiredView() {
+        analyticsLogger.logEventV3Dot1(updateRequiredViewEvent)
+    }
+
+    fun trackBackButton() {
+        analyticsLogger.logEventV3Dot1(backEvent)
+    }
+
+    companion object {
+        fun makeUpdateEvent(context: Context) = with(context) {
+            TrackEvent.Link(
+                isExternal = true,
+                domain = getEnglishString(R.string.openIdConnectBaseUrl, "").domain,
+                text = getEnglishString(R.string.app_updateAppButton),
+                params = RequiredParameters(
+                    taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,
+                    taxonomyLevel3 = TaxonomyLevel3.UNDEFINED
+                )
+            )
+        }
+
+        fun makeUpdateRequiredViewEvent(context: Context) = with(context) {
+            ViewEvent.Screen(
+                name = getEnglishString(R.string.app_updateApp_Title),
+                id = getEnglishString(R.string.update_required_page_id),
+                params = RequiredParameters(
+                    taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,
+                    taxonomyLevel3 = TaxonomyLevel3.UNDEFINED
+                )
+            )
+        }
+
+        fun makeBackEvent(context: Context) = with(context) {
+            TrackEvent.Icon(
+                text = getEnglishString(R.string.system_bottomNavigation_backButton),
+                params = RequiredParameters(
+                    taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,
+                    taxonomyLevel3 = TaxonomyLevel3.UNDEFINED
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.ui.update
+package uk.gov.onelogin.ui.error.update
 
 import android.content.Context
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredAnalyticsViewModel.kt
@@ -15,6 +15,7 @@ import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.logging.api.v3dot1.model.ViewEvent
+import uk.gov.onelogin.appinfo.AppInfoUtils
 
 @HiltViewModel
 class UpdateRequiredAnalyticsViewModel @Inject constructor(
@@ -41,7 +42,7 @@ class UpdateRequiredAnalyticsViewModel @Inject constructor(
         fun makeUpdateEvent(context: Context) = with(context) {
             TrackEvent.Link(
                 isExternal = true,
-                domain = getEnglishString(R.string.openIdConnectBaseUrl, "").domain,
+                domain = AppInfoUtils.GOOGLE_PLAY_URL.domain,
                 text = getEnglishString(R.string.app_updateAppButton),
                 params = RequiredParameters(
                     taxonomyLevel2 = TaxonomyLevel2.APP_SYSTEM,

--- a/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.ui.error.update
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -7,6 +8,9 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.navigation.compose.rememberNavController
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.components.R as UiR
 import uk.gov.android.ui.components.content.GdsContentText
@@ -14,14 +18,25 @@ import uk.gov.android.ui.pages.LandingPage
 import uk.gov.android.ui.pages.LandingPageParameters
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.smallPadding
+import uk.gov.onelogin.navigation.closeApp
 
 @Composable
 fun UpdateRequiredScreen(
     viewModel: UpdateRequiredErrorViewModel = hiltViewModel()
 ) {
+    val analytics: UpdateRequiredAnalyticsViewModel = hiltViewModel()
+    val navController = rememberNavController()
     UpdateRequiredBody(
-        onPrimary = { viewModel.updateApp() }
+        onPrimary = {
+            viewModel.updateApp()
+            analytics.trackAppUpdate()
+        }
     )
+    BackHandler {
+        analytics.trackBackButton()
+        navController.closeApp()
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { analytics.trackUpdateRequiredView() }
 }
 
 @Composable

--- a/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/update/UpdateRequiredErrorScreen.kt
@@ -3,17 +3,30 @@ package uk.gov.onelogin.ui.error.update
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewFontScale
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.components.R as UiR
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.pages.LandingPage
 import uk.gov.android.ui.pages.LandingPageParameters
+import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.smallPadding
 
 @Composable
 fun UpdateRequiredScreen(
     viewModel: UpdateRequiredErrorViewModel = hiltViewModel()
+) {
+    UpdateRequiredBody(
+        onPrimary = { viewModel.updateApp() }
+    )
+}
+
+@Composable
+internal fun UpdateRequiredBody(
+    onPrimary: () -> Unit
 ) {
     LandingPage(
         landingPageParameters = LandingPageParameters(
@@ -32,7 +45,17 @@ fun UpdateRequiredScreen(
             ),
             contentInternalPadding = PaddingValues(bottom = smallPadding),
             primaryButtonText = R.string.app_updateAppButton,
-            onPrimary = { viewModel.updateApp() }
+            onPrimary = onPrimary
         )
     )
+}
+
+@PreviewLightDark
+@PreviewFontScale
+@PreviewScreenSizes
+@Composable
+internal fun UpdateRequiredPreview() {
+    GdsTheme {
+        UpdateRequiredBody {}
+    }
 }

--- a/app/src/main/res/values/screen_ids.xml
+++ b/app/src/main/res/values/screen_ids.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="sign_in_page_id" translatable="false">30a6b339-75a8-44a2-a79a-e108546419bf</string>
     <string name="signed_out_info_page_id" translatable="false">cfc50baa-4b56-4170-9707-cd05b60b6658</string>
+    <string name="update_required_page_id" translatable="false">ae56a0d6-072a-406f-84c7-83759aa4f942</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,4 +133,7 @@
     <string name="app_dataDeletedErrorBullet3">the app has stopped sharing analytics about how you use it</string>
     <string name="app_dataDeletedErrorBody3">To keep using the app, you’ll need to sign in. You’ll then be able to add your documents to your GOV.UK Wallet and set your preferences again.</string>
     <string name="app_dataDeletedError_ContentDescription" translatable="false">Data deleted error (re-auth) icon content description</string>
+
+    <!-- Analytics Values   -->
+    <string name="system_bottomNavigation_backButton" translatable="false">back - system</string>
 </resources>

--- a/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
@@ -3,6 +3,7 @@ package uk.gov.onelogin
 import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -17,6 +18,7 @@ import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.login.biooptin.BiometricPreference
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.navigation.Navigator
+import uk.gov.onelogin.optin.domain.repository.AnalyticsOptInRepository
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.usecases.AutoInitialiseSecureStore
 
@@ -24,6 +26,7 @@ import uk.gov.onelogin.tokens.usecases.AutoInitialiseSecureStore
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class MainActivityViewModelTest {
     private val mockContext: Context = mock()
+    private val analyticsOptInRepo: AnalyticsOptInRepository = mock()
     private val mockBioPrefHandler: BiometricPreferenceHandler = mock()
     private val mockTokenRepository: TokenRepository = mock()
     private val mockAutoInitialiseSecureStore: AutoInitialiseSecureStore = mock()
@@ -45,6 +48,7 @@ class MainActivityViewModelTest {
     @BeforeEach
     fun setup() {
         viewModel = MainActivityViewModel(
+            analyticsOptInRepo,
             mockBioPrefHandler,
             mockTokenRepository,
             mockNavigator,
@@ -73,5 +77,11 @@ class MainActivityViewModelTest {
         verify(mockTokenRepository).clearTokenResponse()
         // AND user navigates to the lock screen (splash screen)
         verify(mockNavigator).navigate(LoginRoutes.Start)
+    }
+
+    @Test
+    fun `synchronise analytics on each app start`() = runTest {
+        viewModel.onStart(owner = mockLifecycleOwner)
+        verify(analyticsOptInRepo).synchronise()
     }
 }


### PR DESCRIPTION
# DCMAW-9613: GA4 schema on the 'You need to update your app' page

- [Ticket DCMAW-9613](https://govukverify.atlassian.net/browse/DCMAW-9613)
- [GA4 Schema v3.1](https://govukverify.atlassian.net/wiki/spaces/PI/pages/3790995627/GA4+One+Login+Mobile+Application+Data+Schema+V3.1)

## Description of changes:

- Built on top of DCMAW-9635, so only the last 6 commits are actually this ticket until 9635 is merged
- Adds Preview to UpdateRequiredScreen
- Updates UpdateRequiredScreen to use Analytics
- Synchronises Analytics preference on App start

## Evidence of the change

User has opted-in to analytics

AC1a: trackScreen analytics [opt-in]
GIVEN I have previously opted in to analytics
WHEN I land on the App update required page
THEN the trackScreen analytics defined in the OpenAPI spec will be sent to GA4
AND the firebase Screen ID [screenView] is set to ae56a0d6-072a-406f-84c7-83759aa4f942
AND no other screenView is fired
AND the taxonomy levels are as per the above table

![DCMAW-9613-ScreenView-1](https://github.com/user-attachments/assets/7ec9d5e4-8149-482c-afd1-5f8f66524a47)
![DCMAW-9613-ScreenView-2](https://github.com/user-attachments/assets/6ef2d7d6-4a9e-4b62-aad6-1028e1d83a7d)

AC2a: trackEventLink analytics ('Update…' link) [opt-in]
GIVEN I have previously opted in to analytics
AND I’m on the ‘App requires update’ page
WHEN I click the 'Update…' button
THEN the trackEventLink analytics defined in the OpenAPI spec will be sent to GA4

![DCMAW-9613-Navigation-1](https://github.com/user-attachments/assets/dcc0b254-cd56-49fd-8ae9-eed027875c4c)
![DCMAW-9613-Navigation-2](https://github.com/user-attachments/assets/73470339-2cca-4207-be1b-e5e23d0b6c95)

AC3a: trackEventIcon analytics (Hardware back button link) [opt-in]
GIVEN I have previously opted in to analytics
AND I’m on the App requires update page
WHEN I click the hardware back button
THEN the trackEventIcon analytics defined in the OpenAPI spec will be sent to GA4
AND the text parameter is set to back - system

![DCMAW-9613-BackButton-1](https://github.com/user-attachments/assets/4d22da61-c9db-45fb-8b14-d4c011b25936)
![DCMAW-9613-BackButton-2](https://github.com/user-attachments/assets/9c2ec41c-17e3-4bd5-9649-74576a354dd2)

User has not opted-in to analytics

AC1b: trackScreen analytics [opt-out]
GIVEN I have not previously opted in to analytics
WHEN I land on the App update required page
THEN no data is sent to GA4

![DCMAW-9613-ScreenView-Disabled](https://github.com/user-attachments/assets/e693113c-1aff-45f4-967e-5cfdd122b6d6)

AC2b: trackEventLink analytics ('Update now' link) [opt-out]
GIVEN I have not previously opted in to analytics
AND I’m on the App update required page
WHEN I click the ‘Update…’ button
THEN no data is sent to GA4

![DCMAW-9613-Navigation-Disabled](https://github.com/user-attachments/assets/b890fd80-d8cd-4af1-94f1-a35514b5f893)

AC3b: trackEventIcon analytics (Hardware back button link) [opt-out]
GIVEN I have previously opted in to analytics
AND I’m on the App requires update page
WHEN I click the hardware back button
THEN no data is sent to GA4

![DCMAW-9613-BackButton-Disabled](https://github.com/user-attachments/assets/bec3c079-42e8-41c9-b090-6841c0b5dfcd)

Analytics always sent in English

AC3: Welsh language analytics
GIVEN user is on the App update required page
WHEN the language parameter is set to CY
THEN any analytics sent are still sent in English

![DCMAW-9613-BackButton-Welsh](https://github.com/user-attachments/assets/8dac386a-f228-49fe-a593-f7fb4b953b76)
![DCMAW-9613-Navigation-Welsh](https://github.com/user-attachments/assets/25b25989-39ba-48cf-9005-f065329ddd1a)
![DCMAW-9613-ScreenView-Welsh](https://github.com/user-attachments/assets/0e7d4aa9-a38c-4c5b-9dac-229962756f0d)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-onelogin-app
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing