### PR TITLE
fix: Fix AppVersionCheck bug

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/appinfo/AppInfoUtils.kt
+++ b/app/src/main/java/uk/gov/onelogin/appinfo/AppInfoUtils.kt
@@ -8,18 +8,13 @@ import javax.inject.Inject
 fun interface AppInfoUtils {
     /**
      * Converts [String] version into [List] of [Int] to allow for comparison between versions.
-     * @throws [AppError.IncorrectVersionFormat] when version does not adhere to conventional commits versioning (e.g.: 1.2.0).
-     * @throws [AppError.IllegalVersionFormat] when version contains illegal elements such as extra letters. The only letter accepted is "v" preceding the version (e.g.: v1.2.0)
+     * @throws [AppError.IllegalVersionFormat] when version does not adhere to conventional commits versioning (e.g.: 1.2.0).
      */
     fun getComparableAppVersion(version: String): List<Int>
 
     sealed class AppError(msg: String) : Exception(msg) {
-        data object IncorrectVersionFormat : AppError(
-            "Version number does not adhere to Major.minor.patch convention."
-        )
-
         data object IllegalVersionFormat : AppError(
-            "The version contains illegal characters not adhering to the standard convention."
+            "Version number does not adhere to Major.minor.patch convention."
         )
     }
 
@@ -31,22 +26,14 @@ fun interface AppInfoUtils {
 
 class AppInfoUtilsImpl @Inject constructor() : AppInfoUtils {
     override fun getComparableAppVersion(version: String): List<Int> {
-        val result = try {
-            version
-                // If version adheres to vM.m.p - remove "v" to allow conversion to Int
-                .replace("v", "")
-                .split(".").map { it.toInt() }
-        } catch (e: NumberFormatException) {
-            throw AppInfoUtils.AppError.IllegalVersionFormat
-        }
-        return if (result.size != SIZE) {
-            throw AppInfoUtils.AppError.IncorrectVersionFormat
-        } else {
-            result
-        }
+        val cleanVersion = pattern.find(version)?.value
+            ?: throw AppInfoUtils.AppError.IllegalVersionFormat
+
+        val result = cleanVersion.split(".").map { it.toInt() }
+        return result
     }
 
     companion object {
-        private const val SIZE = 3
+        private val pattern = "\\d+\\.\\d+\\.\\d+".toRegex()
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/appinfo/appversioncheck/data/AppVersionCheckImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appinfo/appversioncheck/data/AppVersionCheckImpl.kt
@@ -8,6 +8,7 @@ import uk.gov.onelogin.appinfo.apicall.domain.model.AppInfoData
 import uk.gov.onelogin.appinfo.appversioncheck.domain.AppVersionCheck
 import uk.gov.onelogin.appinfo.service.domain.model.AppInfoServiceState
 
+@Suppress("LoopWithTooManyJumpStatements")
 class AppVersionCheckImpl @Inject constructor(
     private val utils: AppInfoUtils,
     @BuildConfigVersion
@@ -20,7 +21,12 @@ class AppVersionCheckImpl @Inject constructor(
             val localVersion = utils.getComparableAppVersion(appVersion)
             val serverVersion = utils.getComparableAppVersion(updatedVersion)
             for (i in serverVersion.indices) {
-                if (localVersion[i] < serverVersion[i]) {
+                // Exit the loop if any of the version parts is bigger - avoid returning [UpdateRequired] when
+                // local version is 1.0.0 but server version is 0.1.0
+                if (localVersion[i] > serverVersion[i]) {
+                    result = AppInfoServiceState.Successful(data)
+                    break
+                } else if (localVersion[i] < serverVersion[i]) {
                     result = AppInfoServiceState.UpdateRequired
                     break
                 } else {

--- a/app/src/main/java/uk/gov/onelogin/appinfo/appversioncheck/data/AppVersionCheckImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appinfo/appversioncheck/data/AppVersionCheckImpl.kt
@@ -8,7 +8,6 @@ import uk.gov.onelogin.appinfo.apicall.domain.model.AppInfoData
 import uk.gov.onelogin.appinfo.appversioncheck.domain.AppVersionCheck
 import uk.gov.onelogin.appinfo.service.domain.model.AppInfoServiceState
 
-@Suppress("LoopWithTooManyJumpStatements")
 class AppVersionCheckImpl @Inject constructor(
     private val utils: AppInfoUtils,
     @BuildConfigVersion
@@ -20,17 +19,21 @@ class AppVersionCheckImpl @Inject constructor(
         try {
             val localVersion = utils.getComparableAppVersion(appVersion)
             val serverVersion = utils.getComparableAppVersion(updatedVersion)
+            var discrepancyFound = false
             for (i in serverVersion.indices) {
                 // Exit the loop if any of the version parts is bigger - avoid returning [UpdateRequired] when
                 // local version is 1.0.0 but server version is 0.1.0
                 if (localVersion[i] > serverVersion[i]) {
                     result = AppInfoServiceState.Successful(data)
-                    break
+                    discrepancyFound = true
                 } else if (localVersion[i] < serverVersion[i]) {
                     result = AppInfoServiceState.UpdateRequired
-                    break
+                    discrepancyFound = true
                 } else {
                     result = AppInfoServiceState.Successful(data)
+                }
+                if (discrepancyFound) {
+                    break
                 }
             }
         } catch (e: AppInfoUtils.AppError) {

--- a/app/src/test/java/uk/gov/onelogin/TestUtils.kt
+++ b/app/src/test/java/uk/gov/onelogin/TestUtils.kt
@@ -18,6 +18,21 @@ object TestUtils {
         )
     )
 
+    val additionalAppInfoData = AppInfoData(
+        apps = AppInfoData.App(
+            AppInfoData.AppInfo(
+                minimumVersion = "1.0.0",
+                releaseFlags = AppInfoData.ReleaseFlags(
+                    true,
+                    true,
+                    true
+                ),
+                available = true,
+                featureFlags = AppInfoData.FeatureFlags(true)
+            )
+        )
+    )
+
     val appInfoDataDisabledFeatures = AppInfoData(
         apps = AppInfoData.App(
             AppInfoData.AppInfo(

--- a/app/src/test/java/uk/gov/onelogin/TestUtils.kt
+++ b/app/src/test/java/uk/gov/onelogin/TestUtils.kt
@@ -51,7 +51,7 @@ object TestUtils {
     val extractVersionErrorAppInfoData = AppInfoData(
         apps = AppInfoData.App(
             AppInfoData.AppInfo(
-                minimumVersion = "vers1.0.0",
+                minimumVersion = "One.Two.Zero",
                 releaseFlags = AppInfoData.ReleaseFlags(
                     true,
                     true,

--- a/app/src/test/java/uk/gov/onelogin/appinfo/AppInfoUtilsTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appinfo/AppInfoUtilsTest.kt
@@ -7,31 +7,22 @@ import org.junit.jupiter.api.assertThrows
 class AppInfoUtilsTest {
     private val correctV = "1.0.0"
     private val correctVersion = "v1.0.0"
-    private val longVersion = "1.0.8.0"
-    private val incorrectVersion = "vers1.0.0"
+    private val githubVersion = "1729695540-1.0.0"
+    private val incorrectVersion = ""
     private val sut = AppInfoUtilsImpl()
 
     @Test
-    fun `check correct version format`() {
-        val result = sut.getComparableAppVersion(correctV)
-        assertEquals(listOf(1, 0, 0), result)
-    }
-
-    @Test
     fun `check conventional correct version format`() {
-        val result = sut.getComparableAppVersion(correctVersion)
+        var result = sut.getComparableAppVersion(correctVersion)
+        assertEquals(listOf(1, 0, 0), result)
+        result = sut.getComparableAppVersion(githubVersion)
+        assertEquals(listOf(1, 0, 0), result)
+        result = sut.getComparableAppVersion(correctV)
         assertEquals(listOf(1, 0, 0), result)
     }
 
-    @Test()
-    fun `conventional commits violation - version has too many arguments`() {
-        assertThrows<AppInfoUtils.AppError.IncorrectVersionFormat> {
-            sut.getComparableAppVersion(longVersion)
-        }
-    }
-
     @Test
-    fun `conventional commits violation - illegal characters`() {
+    fun `conventional commits violation - empty version`() {
         assertThrows<AppInfoUtils.AppError.IllegalVersionFormat> {
             sut.getComparableAppVersion(incorrectVersion)
         }

--- a/app/src/test/java/uk/gov/onelogin/appinfo/appversioncheck/AppVersionCheckImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appinfo/appversioncheck/AppVersionCheckImplTest.kt
@@ -14,8 +14,10 @@ class AppVersionCheckImplTest {
 
     @Test
     fun versionCheckSuccessful() {
-        val result = sut.compareVersions(TestUtils.appInfoData)
+        var result = sut.compareVersions(TestUtils.appInfoData)
         assertEquals(AppInfoServiceState.Successful(TestUtils.appInfoData), result)
+        result = sut.compareVersions(TestUtils.additionalAppInfoData)
+        assertEquals(AppInfoServiceState.Successful(TestUtils.additionalAppInfoData), result)
     }
 
     @Test

--- a/config/styles/config/vocabularies/Base/accept.txt
+++ b/config/styles/config/vocabularies/Base/accept.txt
@@ -54,3 +54,4 @@ veriff
 [Dd]eserialize
 [Uu]ncomment
 onelogin
+[Bb]ackstack


### PR DESCRIPTION
**Ticket Link:** 
[DCMAW-10471](https://govukverify.atlassian.net/browse/DCMAW-10471)

**Description Of Changes:** 
- amend how the version is checked to strip any string given and use a regex pattern that would extract only
if that is found
- add missing condition to `AppVersionCheckImpl` to stop a check if the local version is higher than the remote one early in the flow
- 
**Evidence:**
- this has been unit tested but it cannot be evidenced until published to the PlayStore to see if the fix solved the bug. The ticket will stay in QA until merged and the PlayStore version is checked as working properly.

Definition Of Done Checklist:

- [x] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [x] Relevant integration and end-to-end tests are written
- [ ] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [x] Sonar coverage gates met 
- [x] If feature flagged, Feature is enabled in staging and manually tested to ensure integration

[DCMAW-10471]: https://govukverify.atlassian.net/browse/DCMAW-10471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ