### PR TITLE
Feat: DCMAW-10331 Update copy on the SignOut page

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutBodyTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutBodyTest.kt
@@ -1,0 +1,124 @@
+package uk.gov.onelogin.signOut.ui
+
+import android.content.Context
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import junit.framework.TestCase.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import uk.gov.android.onelogin.R
+import uk.gov.android.ui.pages.R as T
+
+class SignOutBodyTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var title: SemanticsMatcher
+    private lateinit var body1: SemanticsMatcher
+    private lateinit var subtitle: SemanticsMatcher
+    private lateinit var bullet1: SemanticsMatcher
+    private lateinit var bullet2: SemanticsMatcher
+    private lateinit var bullet3: SemanticsMatcher
+    private lateinit var body3: SemanticsMatcher
+    private lateinit var primaryButton: SemanticsMatcher
+    private lateinit var closeButton: SemanticsMatcher
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        with(context) {
+            title = hasText(getString(R.string.app_signOutConfirmationTitle))
+            body1 = hasText(getString(R.string.app_signOutConfirmationBody1), substring = true)
+            subtitle = hasText(
+                getString(R.string.app_signOutConfirmationSubtitle),
+                substring = true
+            )
+            bullet1 = hasText(getString(R.string.app_signOutConfirmationBullet1), substring = true)
+            bullet2 = hasText(getString(R.string.app_signOutConfirmationBullet2), substring = true)
+            bullet3 = hasText(getString(R.string.app_signOutConfirmationBullet3), substring = true)
+            body3 = hasText(getString(R.string.app_signOutConfirmationBody3), substring = true)
+            primaryButton = hasText(getString(R.string.app_signOutAndDeleteAppDataButton))
+            closeButton = hasContentDescription(getString(T.string.preview__alertPage__close))
+        }
+    }
+
+    @Test
+    fun verifyWalletStrings() {
+        // Given the SignOutBody Composable
+        composeTestRule.setContent {
+            SignOutBody(SignOutUIState.Wallet, {}, {})
+        }
+        // Then the UI elements are visible
+        with(composeTestRule) {
+            onNode(title).assertIsDisplayed()
+            onNode(body1).assertIsDisplayed()
+            onNode(subtitle).assertIsDisplayed()
+            onNode(bullet1).assertIsDisplayed()
+            onNode(bullet2).assertIsDisplayed()
+            onNode(bullet3).assertIsDisplayed()
+            onNode(body3).assertIsDisplayed()
+            onNode(primaryButton).assertIsDisplayed()
+            onNode(closeButton).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun verifyNoWalletStrings() {
+        // Given the SignOutBody Composable
+        composeTestRule.setContent {
+            SignOutBody(SignOutUIState.NoWallet, {}, {})
+        }
+        // Then the UI elements are visible
+        with(composeTestRule) {
+            onNode(title).assertIsDisplayed()
+            onNode(body1).assertIsDisplayed()
+            onNode(subtitle).assertIsDisplayed()
+            onNode(bullet1).assertIsDisplayed()
+            onNode(bullet2).assertIsDisplayed()
+            onNode(bullet3).assertIsDisplayed()
+            onNode(body3).assertIsDisplayed()
+            onNode(primaryButton).assertIsDisplayed()
+            onNode(closeButton).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun onClose() {
+        // Given the SignOutBody Composable
+        var actual = false
+        composeTestRule.setContent {
+            SignOutBody(
+                uiState = SignOutUIState.Wallet,
+                onPrimary = {},
+                onClose = { actual = true }
+            )
+        }
+        // When clicking the `closeButton`
+        composeTestRule.onNode(closeButton).performClick()
+        // Then onClose() is called and the variable is true
+        assertEquals(true, actual)
+    }
+
+    @Test
+    fun onPrimary() {
+        // Given the SignOutBody Composable
+        var actual = false
+        composeTestRule.setContent {
+            SignOutBody(
+                uiState = SignOutUIState.Wallet,
+                onPrimary = { actual = true },
+                onClose = {}
+            )
+        }
+        // When clicking the `primaryButton`
+        composeTestRule.onNode(primaryButton).performClick()
+        // Then onPrimary() is called and the variable is true
+        assertEquals(true, actual)
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutScreenTest.kt
@@ -54,25 +54,31 @@ class SignOutScreenTest : TestCase() {
     @Before
     fun setupNavigation() {
         hiltRule.inject()
-        composeTestRule.setContent {
-            SignOutScreen()
-        }
     }
 
     @Test
     fun verifyScreenDisplayed() {
+        composeTestRule.setContent {
+            SignOutScreen()
+        }
         composeTestRule.onNode(title).assertIsDisplayed()
     }
 
     @Test
     fun verifySignOutButtonSucceeds() = runBlocking {
+        composeTestRule.setContent {
+            SignOutScreen()
+        }
         composeTestRule.onNode(ctaButton).performClick()
         verify(signOutUseCase).invoke(any())
         verify(mockNavigator).navigate(LoginRoutes.Root, true)
     }
 
-    @Test()
+    @Test
     fun verifySignOutButtonFails() = runTest {
+        composeTestRule.setContent {
+            SignOutScreen()
+        }
         whenever(signOutUseCase.invoke(any()))
             .thenThrow(SignOutError(Exception("something went wrong")))
         composeTestRule.onNode(ctaButton).performClick()
@@ -82,7 +88,24 @@ class SignOutScreenTest : TestCase() {
 
     @Test
     fun verifyGoBackButton() {
+        composeTestRule.setContent {
+            SignOutScreen()
+        }
         composeTestRule.onNode(goBackButton).performClick()
         verify(mockNavigator).goBack()
+    }
+
+    @Test
+    fun previewWalletTest() {
+        composeTestRule.setContent {
+            SignOutWalletPreview()
+        }
+    }
+
+    @Test
+    fun previewNoWalletTest() {
+        composeTestRule.setContent {
+            SignOutNoWalletPreview()
+        }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
@@ -8,11 +8,15 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.pages.AlertPage
 import uk.gov.android.ui.pages.AlertPageParameters
+import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.onelogin.core.meta.ExcludeFromJacocoGeneratedReport
+import uk.gov.onelogin.core.meta.ScreenPreview
 
 @Composable
 fun SignOutScreen(
@@ -20,26 +24,43 @@ fun SignOutScreen(
 ) {
     // Needed for deleteWalletData
     val fragmentActivity = LocalContext.current as FragmentActivity
+    SignOutBody(
+        uiState = viewModel.uiState,
+        onClose = {
+            viewModel.goBack()
+        },
+        onPrimary = {
+            viewModel.signOut(fragmentActivity)
+        }
+    )
+}
+
+@Suppress("unused")
+@Composable
+internal fun SignOutBody(
+    uiState: SignOutUIState,
+    onPrimary: () -> Unit,
+    onClose: () -> Unit
+) {
     AlertPage(
         alertPageParameters = AlertPageParameters(
             title = R.string.app_signOutConfirmationTitle,
             annotatedContent = buildAnnotatedString {
                 append(stringResource(id = R.string.app_signOutConfirmationBody1))
+                appendLine()
+                appendLine()
+                append(stringResource(id = R.string.app_signOutConfirmationSubtitle))
+                appendLine()
                 appendBulletLine(stringResource(id = R.string.app_signOutConfirmationBullet1))
                 appendBulletLine(stringResource(id = R.string.app_signOutConfirmationBullet2))
                 appendBulletLine(stringResource(id = R.string.app_signOutConfirmationBullet3))
                 appendLine()
-                appendBoldLine(stringResource(id = R.string.app_signOutConfirmationBody2))
                 appendLine()
                 append(stringResource(id = R.string.app_signOutConfirmationBody3))
             },
             ctaText = R.string.app_signOutAndDeleteAppDataButton,
-            onClose = {
-                viewModel.goBack()
-            },
-            onPrimary = {
-                viewModel.signOut(fragmentActivity)
-            }
+            onClose = onClose,
+            onPrimary = onPrimary
         )
     )
 }
@@ -52,10 +73,28 @@ private fun AnnotatedString.Builder.appendBulletLine(string: String) {
     append(string)
 }
 
-private fun AnnotatedString.Builder.appendBoldLine(string: String) {
-    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
-        appendLine()
-        append(string)
-        appendLine()
+@ExcludeFromJacocoGeneratedReport
+@ScreenPreview
+@Composable
+internal fun SignOutWalletPreview() {
+    GdsTheme {
+        SignOutBody(
+            uiState = SignOutUIState.Wallet,
+            onPrimary = {},
+            onClose = {}
+        )
+    }
+}
+
+@ExcludeFromJacocoGeneratedReport
+@PreviewLightDark
+@Composable
+internal fun SignOutNoWalletPreview() {
+    GdsTheme {
+        SignOutBody(
+            uiState = SignOutUIState.NoWallet,
+            onPrimary = {},
+            onClose = {}
+        )
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutUIState.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutUIState.kt
@@ -1,0 +1,3 @@
+package uk.gov.onelogin.signOut.ui
+
+enum class SignOutUIState { Wallet, NoWallet }

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutViewModel.kt
@@ -7,6 +7,8 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import uk.gov.android.features.FeatureFlags
+import uk.gov.onelogin.features.WalletFeatureFlag
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.navigation.Navigator
 import uk.gov.onelogin.signOut.domain.SignOutError
@@ -16,8 +18,16 @@ import uk.gov.onelogin.ui.error.ErrorRoutes
 @HiltViewModel
 class SignOutViewModel @Inject constructor(
     private val navigator: Navigator,
-    private val signOutUseCase: SignOutUseCase
+    private val signOutUseCase: SignOutUseCase,
+    private val featureFlags: FeatureFlags
 ) : ViewModel() {
+    val uiState: SignOutUIState
+        get() = if (featureFlags[WalletFeatureFlag.ENABLED]) {
+            SignOutUIState.Wallet
+        } else {
+            SignOutUIState.NoWallet
+        }
+
     fun signOut(activityFragment: FragmentActivity) {
         viewModelScope.launch {
             try {

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -22,14 +22,15 @@
     <string name="sign_in_url">https://signin.account.gov.uk/sign-in-or-create?lng=cy</string>
 
     <!-- Sign Out-->
-    <string name="app_signOutConfirmationTitle">Bydd allgofnodi yn dileu data eich ap</string>
-    <string name="app_signOutConfirmationBody1">Pan fyddwch yn allgofnodi, bydd yr holl wybodaeth a dogfennau a gedwir yn eich ap yn cael eu dileu, gan gynnwys:</string>
-    <string name="app_signOutConfirmationBullet1">unrhyw ddogfennau a arbedwyd yn eich GOV.UK Wallet</string>
-    <string name="app_signOutConfirmationBullet2">eich gosodiadau ar gyfer mewngofnodi</string>
-    <string name="app_signOutConfirmationBullet3">eich dewisiadau rhannu dadansoddi</string>
-    <string name="app_signOutConfirmationBody2">Mae hyn er mwyn cadw\'ch gwybodaeth yn ddiogel.</string>
-    <string name="app_signOutConfirmationBody3">Bydd unrhyw ddogfennau sydd wedi\'u dileu yn dal i fod ar gael ar-lein i chi eu hychwanegu at eich GOV.UK Wallet eto.</string>
-    <string name="app_signOutAndDeleteAppDataButton">Allgofnodwch a dileu data yr ap</string>
+    <string name="app_signOutConfirmationTitle">Ydych chi\'n siwr eich bod chi eisiau allgofnodi?</string>
+    <string name="app_signOutConfirmationBody1">Os byddwch yn allgofnodi, bydd y wybodaeth a gedwir yn eich ap yn cael ei dileu. Mae hyn er mwyn lleihau\'r risg y bydd rhywun arall yn gweld eich gwybodaeth.</string>
+    <string name="app_signOutConfirmationSubtitle">Mae hyn yn golygu:</string>
+    <string name="app_signOutConfirmationBullet1">bydd unrhyw ddogfennau a arbedir yn eich GOV.UK Wallet yn cael eu dileu</string>
+    <string name="app_signOutConfirmationBullet2">os ydych yn defnyddio biometreg neu pin neu batrwm eich ffôn i ddatgloi\'r ap, bydd hyn yn cael ei ddiffodd</string>
+    <string name="app_signOutConfirmationBullet3">byddwch yn stopio rhannu dadansoddeg am sut rydych yn defnyddio\'r ap</string>
+    <string name="app_signOutConfirmationBody3">Y tro nesaf y byddwch yn mewngofnodi, gallwch ychwanegu eich dogfennau at eich GOV.UK Wallet a gosod eich dewisiadau eto.</string>
+    <string name="app_signOutAndDeleteAppDataButton">Mewngofnodi a dileu gwybodaeth</string>
+
     <string name="app_youveBeenSignedOutTitle">Rydych wedi cael eich allgofnodi</string>
     <string name="app_youveBeenSignedOutBody1">Mae hyn er mwyn cadw\'r wybodaeth yn eich ap GOV.UK One Login yn ddiogel.</string>
     <string name="app_youveBeenSignedOutBody2">Mae angen i chi fewngofnodi eto i barhau.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,14 +24,15 @@
     <string name="sign_in_url">https://signin.account.gov.uk/sign-in-or-create?lng=en</string>
 
     <!-- Sign Out -->
-    <string name="app_signOutConfirmationTitle">Signing out will delete your app data</string>
-    <string name="app_signOutConfirmationBody1">When you sign out, all the information and documents saved in your app will be deleted, including:</string>
-    <string name="app_signOutConfirmationBullet1">any documents saved in your GOV.UK Wallet</string>
-    <string name="app_signOutConfirmationBullet2">your settings for signing in</string>
-    <string name="app_signOutConfirmationBullet3">your analytics sharing preferences</string>
-    <string name="app_signOutConfirmationBody2">This is to keep your information secure.</string>
-    <string name="app_signOutConfirmationBody3">Any deleted documents will still be available online for you to add to your GOV.UK Wallet again.</string>
-    <string name="app_signOutAndDeleteAppDataButton">Sign out and delete app data</string>
+    <string name="app_signOutConfirmationTitle">Are you sure you want to sign out?</string>
+    <string name="app_signOutConfirmationBody1">If you sign out, the information saved in your app will be deleted. This is to reduce the risk that someone else will see your information.</string>
+    <string name="app_signOutConfirmationSubtitle">This means:</string>
+    <string name="app_signOutConfirmationBullet1">any documents saved in your GOV.UK Wallet will be removed</string>
+    <string name="app_signOutConfirmationBullet2">if you’re using biometrics or your phone’s pin or pattern to unlock the app, this will be switched off</string>
+    <string name="app_signOutConfirmationBullet3">you’ll stop sharing analytics about how you use the app</string>
+    <string name="app_signOutConfirmationBody3">Next time you sign in, you’ll be able to add your documents to your GOV.UK  Wallet and set your preferences again.</string>
+    <string name="app_signOutAndDeleteAppDataButton">Sign out and delete information</string>
+
     <string name="app_youveBeenSignedOutTitle">You’ve been signed out</string>
     <string name="app_youveBeenSignedOutBody1">This is to keep the information in your GOV.UK One Login app secure.</string>
     <string name="app_youveBeenSignedOutBody2">You need to sign in again to continue.</string>

--- a/app/src/test/java/uk/gov/onelogin/signOut/ui/SignOutUIStateTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/signOut/ui/SignOutUIStateTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.onelogin.signOut.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import uk.gov.onelogin.optin.ui.OptInUIState
+
+class SignOutUIStateTest {
+
+    @Test
+    fun wallet() {
+        val state = SignOutUIState.Wallet
+        assertEquals(expected = state, actual = SignOutUIState.valueOf("Wallet"))
+    }
+
+    @Test
+    fun `no wallet`() {
+        val state = SignOutUIState.NoWallet
+        assertEquals(expected = state, actual = SignOutUIState.valueOf("NoWallet"))
+    }
+
+    @Test
+    fun values() {
+        val list = SignOutUIState.values()
+        assertEquals(expected = 2, actual = list.size)
+    }
+
+    @Test
+    fun entries() {
+        val list = OptInUIState.entries
+        assertEquals(expected = 2, actual = list.size)
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/signOut/ui/SignOutViewModelTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.signOut.ui
 
 import androidx.fragment.app.FragmentActivity
+import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -9,8 +10,10 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.android.features.FeatureFlags
 import uk.gov.onelogin.extensions.CoroutinesTestExtension
 import uk.gov.onelogin.extensions.InstantExecutorExtension
+import uk.gov.onelogin.features.WalletFeatureFlag
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.navigation.Navigator
 import uk.gov.onelogin.signOut.domain.SignOutError
@@ -25,13 +28,16 @@ class SignOutViewModelTest {
     private val mockNavigator: Navigator = mock()
     private val mockActivity: FragmentActivity = mock()
     private val mockSignOutUseCase: SignOutUseCase = mock()
+    private val featureFlags: FeatureFlags = mock()
 
     @BeforeEach
     fun setup() {
         viewModel = SignOutViewModel(
             mockNavigator,
-            mockSignOutUseCase
+            mockSignOutUseCase,
+            featureFlags
         )
+        whenever(featureFlags[WalletFeatureFlag.ENABLED]).then { true }
     }
 
     @Test
@@ -57,5 +63,19 @@ class SignOutViewModelTest {
         viewModel.goBack()
 
         verify(mockNavigator).goBack()
+    }
+
+    @Test
+    fun `uiState Wallet`() {
+        whenever(featureFlags[WalletFeatureFlag.ENABLED]).then { true }
+        val actual = viewModel.uiState
+        assertEquals(expected = SignOutUIState.Wallet, actual = actual)
+    }
+
+    @Test
+    fun `uiState No Wallet`() {
+        whenever(featureFlags[WalletFeatureFlag.ENABLED]).then { false }
+        val actual = viewModel.uiState
+        assertEquals(expected = SignOutUIState.NoWallet, actual = actual)
     }
 }


### PR DESCRIPTION
# DCMAW-10331: Update copy on the Sign out confirmation page (with Wallet copy)

- [Ticket DCMAW-10331](https://govukverify.atlassian.net/browse/DCMAW-10331)

## Description of changes:

- Updates the copy on the SignOut page
- Adds SignOutUIState enum for future use
- This PR does not deal with the style / design changes that are required as they need to be done in the mobile-ui project

## Evidence of the change

English
![DCMAW-10331-English](https://github.com/user-attachments/assets/a02386d2-680d-4d98-9c99-7a6be663216b)

Welsh
![DCMAW-10331-Welsh](https://github.com/user-attachments/assets/d90a973a-87ec-4caa-9c2e-9bda3c8421d9)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- ~[ ] Complete all Acceptance Criteria within Jira ticket.~
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- ~[ ] Review [Accessibility considerations].~
- [x] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-onelogin-app
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing