### PR TITLE
feat: Generate Proof of Possession

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/appcheck/FirebaseAppCheckTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/appcheck/FirebaseAppCheckTest.kt
@@ -8,7 +8,7 @@ import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 
 class FirebaseAppCheckTest {
     private val context: Context = ApplicationProvider.getApplicationContext()

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.UninstallModules
 import javax.inject.Inject
 import javax.inject.Named
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -22,9 +23,11 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.integrity.ClientAttestationManager
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
+import uk.gov.android.authentication.integrity.keymanager.ECKeyManager
+import uk.gov.android.authentication.integrity.keymanager.KeyStoreManager
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration
-import uk.gov.android.authentication.integrity.usecase.AttestationCaller
 import uk.gov.android.authentication.login.LoginSession
 import uk.gov.android.authentication.login.LoginSessionConfiguration
 import uk.gov.android.authentication.login.LoginSessionConfiguration.Locale
@@ -52,6 +55,7 @@ import uk.gov.onelogin.network.di.NetworkModule
 import uk.gov.onelogin.tokens.Keys
 import uk.gov.onelogin.ui.error.ErrorRoutes
 
+@OptIn(ExperimentalEncodingApi::class)
 @HiltAndroidTest
 @UninstallModules(
     LoginSessionModule::class,
@@ -98,9 +102,13 @@ class WelcomeScreenTest : TestCase() {
     val mockAppChecker: AppChecker = mock()
 
     @BindValue
+    val mockKeyStoreManager: KeyStoreManager = ECKeyManager()
+
+    @BindValue
     val mockAppIntegrityConfiguration: AppIntegrityConfiguration = AppIntegrityConfiguration(
         mockAttestationCaller,
-        mockAppChecker
+        mockAppChecker,
+        mockKeyStoreManager
     )
 
     @Inject

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="openIdConnectBaseUrl" translatable="false">https://auth-stub.mobile.build.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.build.account.gov.uk%1$s</string>
+    <string name="baseStsUrl" translatable="false">https://token.build.account.gov.uk%1$s</string>
     <string name="openIdConnectClientId" translatable="false">TEST_CLIENT_ID</string>
     <string name="stsClientId" translatable="false">bYrcuRVvnylvEgYSSbBjwXzHrwJ</string>
     <string name="webBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>

--- a/app/src/debug/kotlin/uk/gov/onelogin/appcheck/AppCheckModule.kt
+++ b/app/src/debug/kotlin/uk/gov/onelogin/appcheck/AppCheckModule.kt
@@ -10,7 +10,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.android.onelogin.BuildConfig
 
 @Module

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrity.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrity.kt
@@ -1,7 +1,10 @@
 package uk.gov.onelogin.appcheck
 
-fun interface AppIntegrity {
+import uk.gov.android.authentication.integrity.pop.SignedPoP
+
+interface AppIntegrity {
     suspend fun getClientAttestation(): AttestationResult
+    fun getProofOfPossession(): SignedPoP
 
     companion object {
         const val CLIENT_ATTESTATION = "appCheckClientAttestation"

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -1,11 +1,14 @@
 package uk.gov.onelogin.appcheck
 
+import android.content.Context
 import android.util.Log
 import io.ktor.util.date.getTimeMillis
 import javax.inject.Inject
 import uk.gov.android.authentication.integrity.ClientAttestationManager
-import uk.gov.android.authentication.integrity.model.AttestationResponse
+import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
+import uk.gov.android.authentication.integrity.pop.SignedPoP
 import uk.gov.android.features.FeatureFlags
+import uk.gov.android.onelogin.R
 import uk.gov.android.securestore.error.SecureStorageError
 import uk.gov.onelogin.appcheck.AppIntegrity.Companion.CLIENT_ATTESTATION
 import uk.gov.onelogin.appcheck.AppIntegrity.Companion.CLIENT_ATTESTATION_EXPIRY
@@ -15,6 +18,7 @@ import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
 
 class AppIntegrityImpl @Inject constructor(
+    private val context: Context,
     private val featureFlags: FeatureFlags,
     private val appCheck: ClientAttestationManager,
     private val saveToOpenSecureStore: SaveToOpenSecureStore,
@@ -37,6 +41,13 @@ class AppIntegrityImpl @Inject constructor(
         } else {
             AttestationResult.NotRequired
         }
+    }
+
+    override fun getProofOfPossession(): SignedPoP {
+        return appCheck.generatePoP(
+            iss = context.getString(R.string.stsClientId),
+            aud = context.getString(R.string.baseStsUrl)
+        )
     }
 
     private suspend fun handleClientAttestation(result: AttestationResponse.Success) =

--- a/app/src/main/java/uk/gov/onelogin/appcheck/FirebaseAppCheck.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/FirebaseAppCheck.kt
@@ -8,8 +8,8 @@ import com.google.firebase.appcheck.appCheck
 import com.google.firebase.initialize
 import javax.inject.Inject
 import kotlinx.coroutines.tasks.await
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
-import uk.gov.android.authentication.integrity.model.AppCheckToken
+import uk.gov.android.authentication.integrity.appcheck.model.AppCheckToken
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 
 class FirebaseAppCheck @Inject constructor(
     private val appCheckFactory: AppCheckProviderFactory,

--- a/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AppCheckUseCaseModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AppCheckUseCaseModule.kt
@@ -6,11 +6,14 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlin.io.encoding.ExperimentalEncodingApi
 import uk.gov.android.authentication.integrity.ClientAttestationManager
 import uk.gov.android.authentication.integrity.FirebaseClientAttestationManager
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
+import uk.gov.android.authentication.integrity.keymanager.ECKeyManager
+import uk.gov.android.authentication.integrity.keymanager.KeyStoreManager
 import uk.gov.android.authentication.integrity.model.AppIntegrityConfiguration
-import uk.gov.android.authentication.integrity.usecase.AttestationCaller
 import uk.gov.android.features.FeatureFlags
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.onelogin.appcheck.AppIntegrity
@@ -25,11 +28,13 @@ object AppCheckUseCaseModule {
     @Provides
     fun provideAppIntegrityConfig(
         attestationCaller: AttestationCaller,
-        appChecker: AppChecker
+        appChecker: AppChecker,
+        keyStoreManager: KeyStoreManager
     ): AppIntegrityConfiguration {
         return AppIntegrityConfiguration(
             attestationCaller = attestationCaller,
-            appChecker = appChecker
+            appChecker = appChecker,
+            keyStoreManager = keyStoreManager
         )
     }
 
@@ -42,12 +47,15 @@ object AppCheckUseCaseModule {
 
     @Provides
     fun provideAppIntegrityCheck(
+        @ApplicationContext
+        context: Context,
         featureFlags: FeatureFlags,
         appCheck: ClientAttestationManager,
         saveToOpenSecureStore: SaveToOpenSecureStore,
         getFromOpenSecureStore: GetFromOpenSecureStore
     ): AppIntegrity {
         return AppIntegrityImpl(
+            context,
             featureFlags,
             appCheck,
             saveToOpenSecureStore,
@@ -61,4 +69,8 @@ object AppCheckUseCaseModule {
         context: Context,
         genericHttpClient: GenericHttpClient
     ): AttestationCaller = AttestationApiCall(context, genericHttpClient)
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Provides
+    fun provideECKeyManager(): KeyStoreManager = ECKeyManager()
 }

--- a/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.serialization.json.Json
-import uk.gov.android.authentication.integrity.model.AttestationResponse
-import uk.gov.android.authentication.integrity.usecase.AttestationCaller
-import uk.gov.android.authentication.integrity.usecase.JWK
+import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
+import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
+import uk.gov.android.authentication.integrity.appcheck.usecase.JWK
 import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient

--- a/app/src/main/java/uk/gov/onelogin/developer/DeveloperPanelScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/DeveloperPanelScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountBox
-import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Lock
@@ -40,9 +40,9 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import uk.gov.android.onelogin.R
 import uk.gov.onelogin.developer.tabs.app.AppTabScreen
+import uk.gov.onelogin.developer.tabs.appintegrity.AppIntegrityTabScreen
 import uk.gov.onelogin.developer.tabs.auth.AuthTabScreen
 import uk.gov.onelogin.developer.tabs.features.FeaturesScreen
-import uk.gov.onelogin.developer.tabs.networking.NetworkingTabScreen
 import uk.gov.onelogin.developer.tabs.tokens.TokenTabScreen
 import uk.gov.onelogin.ui.components.SimpleTextPage
 
@@ -59,8 +59,8 @@ fun TabView(goBack: () -> Unit) {
         TabItem(R.string.app_developer_tab_tokens, Icons.Filled.LocationOn) {
             TokenTabScreen()
         },
-        TabItem(R.string.app_developer_tab_networking, Icons.Filled.Email) {
-            NetworkingTabScreen()
+        TabItem(R.string.app_developer_tab_app_integrity, Icons.Filled.CheckCircle) {
+            AppIntegrityTabScreen()
         },
         TabItem(
             R.string.app_developer_tab_feature_flags,

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabScreen.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.developer.tabs.networking
+package uk.gov.onelogin.developer.tabs.appintegrity
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,8 +22,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.ui.theme.smallPadding
 
 @Composable
-fun NetworkingTabScreen(
-    viewModel: NetworkingViewModel = hiltViewModel()
+fun AppIntegrityTabScreen(
+    viewModel: AppIntegrityTabViewModel = hiltViewModel()
 ) {
     Column(
         modifier = Modifier
@@ -56,9 +56,15 @@ fun NetworkingTabScreen(
         )
 
         ActionItem(
-            action = { viewModel.startAppIntegrityCheck() },
-            result = viewModel.appIntegrityResult,
-            buttonText = "Start App Integrity Check"
+            action = { viewModel.getClientAttestation() },
+            result = viewModel.clientAttestationResult,
+            buttonText = "Get Client Attestation"
+        )
+
+        ActionItem(
+            action = { viewModel.generatePoP() },
+            result = viewModel.proofOfPossessionResult,
+            buttonText = "Generate Proof Of Possession"
         )
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabViewModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.developer.tabs.networking
+package uk.gov.onelogin.developer.tabs.appintegrity
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
@@ -8,18 +8,19 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import uk.gov.android.authentication.integrity.ClientAttestationManager
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.onelogin.appcheck.AppIntegrity
 
 @HiltViewModel
-class NetworkingViewModel @Inject constructor(
+class AppIntegrityTabViewModel @Inject constructor(
     private val firebaseAppCheck: AppChecker,
     private val appCheck: ClientAttestationManager,
     private val appIntegrity: AppIntegrity
 ) : ViewModel() {
     val tokenResponse: MutableState<String> = mutableStateOf("")
     val networkResponse: MutableState<String> = mutableStateOf("")
-    val appIntegrityResult: MutableState<String> = mutableStateOf("")
+    val clientAttestationResult: MutableState<String> = mutableStateOf("")
+    val proofOfPossessionResult: MutableState<String> = mutableStateOf("")
 
     fun getToken() {
         viewModelScope.launch {
@@ -35,10 +36,15 @@ class NetworkingViewModel @Inject constructor(
         }
     }
 
-    fun startAppIntegrityCheck() {
+    fun getClientAttestation() {
         viewModelScope.launch {
-            appIntegrityResult.value = "Loading..."
-            appIntegrityResult.value = appIntegrity.getClientAttestation().toString()
+            clientAttestationResult.value = "Loading..."
+            clientAttestationResult.value = appIntegrity.getClientAttestation().toString()
         }
+    }
+
+    fun generatePoP() {
+        proofOfPossessionResult.value = "Loading..."
+        proofOfPossessionResult.value = appIntegrity.getProofOfPossession().toString()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,7 +91,7 @@
     <string name="app_developer_tab_app" translatable="false">App</string>
     <string name="app_developer_tab_feature_flags" translatable="false">Feature Flags</string>
     <string name="app_developer_tab_auth" translatable="false">Auth</string>
-    <string name="app_developer_tab_networking" translatable="false">Networking</string>
+    <string name="app_developer_tab_app_integrity" translatable="false">AppIntegrity</string>
     <string name="app_developer_tab_secure_store" translatable="false">Secure Store</string>
     <string name="app_developer_tab_tokens" translatable="false">Tokens</string>
     <string name="app_developer_features_title" translatable="false">Select Features</string>

--- a/app/src/production/res/values/login_flow.xml
+++ b/app/src/production/res/values/login_flow.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="openIdConnectBaseUrl" translatable="false">https://oidc.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.account.gov.uk%1$s</string>
+    <string name="baseStsUrl" translatable="false">https://token.account.gov.uk</string>
     <string name="openIdConnectClientId" translatable="false">CLIENT_ID</string>
     <string name="stsClientId" translatable="false">ctQpngJQrFFCrppZtYQFFoklHaq</string>
     <string name="webBaseUrl" translatable="false">https://mobile.account.gov.uk%1$s</string>

--- a/app/src/release/kotlin/uk/gov/onelogin/appcheck/AppCheckModule.kt
+++ b/app/src/release/kotlin/uk/gov/onelogin/appcheck/AppCheckModule.kt
@@ -7,7 +7,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import uk.gov.android.authentication.integrity.appcheck.AppChecker
+import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/staging/res/values/login_flow.xml
+++ b/app/src/staging/res/values/login_flow.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="openIdConnectBaseUrl" translatable="false">https://oidc.integration.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.staging.account.gov.uk%1$s</string>
+    <string name="baseStsUrl" translatable="false">https://token.staging.account.gov.uk</string>
     <string name="openIdConnectClientId" translatable="false">sdJChz1oGajIz0O0tdPdh0CA2zW</string>
     <string name="stsClientId" translatable="false">ctQpngJQrFFCrppZtYQFFoklHaq</string>
     <string name="webBaseUrl" translatable="false">https://mobile.staging.account.gov.uk%1$s</string>

--- a/app/src/test/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCallTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCallTest.kt
@@ -10,9 +10,9 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.android.authentication.integrity.model.AttestationResponse
-import uk.gov.android.authentication.integrity.usecase.AttestationCaller
-import uk.gov.android.authentication.integrity.usecase.JWK
+import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
+import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
+import uk.gov.android.authentication.integrity.appcheck.usecase.JWK
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
 

--- a/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -15,6 +15,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.integrity.pop.SignedPoP
 import uk.gov.android.authentication.login.AuthenticationError
 import uk.gov.android.authentication.login.LoginSession
 import uk.gov.android.authentication.login.TokenResponse
@@ -102,6 +103,8 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getProofOfPossession())
+                .thenReturn(SignedPoP.Success("Success"))
             whenever(mockLoginSession.finalise(eq(mockIntent), any()))
                 .thenAnswer {
                     (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -121,6 +124,25 @@ class WelcomeScreenViewModelTest {
             verify(mockNavigator).navigate(MainNavRoutes.Start, true)
         }
 
+    @Test
+    fun `handleIntent when data != null, device secure, generatePoP failure`() =
+        runTest {
+            val mockIntent: Intent = mock()
+            val mockUri: Uri = mock()
+
+            whenever(mockIntent.data).thenReturn(mockUri)
+            whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
+            whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getProofOfPossession())
+                .thenReturn(SignedPoP.Failure("Error"))
+
+            viewModel.handleActivityResult(
+                mockIntent
+            )
+
+            verify(mockNavigator).navigate(LoginRoutes.SignInError, true)
+        }
+
     @Suppress("UNCHECKED_CAST")
     @Test
     fun `when data != null, device secure, verify id token success, bio pref set to biometrics`() =
@@ -132,6 +154,8 @@ class WelcomeScreenViewModelTest {
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
             whenever(mockBioPrefHandler.getBioPref()).thenReturn(BiometricPreference.BIOMETRICS)
+            whenever(mockAppIntegrity.getProofOfPossession())
+                .thenReturn(SignedPoP.Success("Success"))
             whenever(mockLoginSession.finalise(eq(mockIntent), any()))
                 .thenAnswer {
                     (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -167,6 +191,8 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getProofOfPossession())
+                .thenReturn(SignedPoP.Success("Success"))
             whenever(mockLoginSession.finalise(eq(mockIntent), any()))
                 .thenAnswer {
                     (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(nullIdTokenResponse)
@@ -191,6 +217,8 @@ class WelcomeScreenViewModelTest {
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
         whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenAnswer {
                 (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -216,6 +244,8 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
+            whenever(mockAppIntegrity.getProofOfPossession())
+                .thenReturn(SignedPoP.Success("Success"))
             whenever(mockLoginSession.finalise(eq(mockIntent), any()))
                 .thenAnswer {
                     (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -240,6 +270,8 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(false)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenAnswer {
                 (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -264,6 +296,8 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(false)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenAnswer {
                 (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -288,6 +322,8 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenAnswer {
                 (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
@@ -324,6 +360,8 @@ class WelcomeScreenViewModelTest {
         val mockUri: Uri = mock()
 
         whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenThrow(
                 AuthenticationError(
@@ -348,6 +386,8 @@ class WelcomeScreenViewModelTest {
         val mockUri: Uri = mock()
 
         whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockAppIntegrity.getProofOfPossession())
+            .thenReturn(SignedPoP.Success("Success"))
         whenever(mockLoginSession.finalise(eq(mockIntent), any()))
             .thenAnswer {
                 (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.10.1" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.11.0" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }


### PR DESCRIPTION
- amend hilt dependencies on the authentication module to provide a KeyStoreManager
- generate the PoP Jwt when loginSession.finalise() and handle logic based on result
- update app integrity imports with the new structure from the latest authentication version

Resolves: DCMAW-10314