### PR TITLE
feat: Add conditional logic to App Integrity call

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.e2e
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.LocalActivityResultRegistryOwner
@@ -95,6 +96,9 @@ class LoginTest : TestCase() {
     @Named("Open")
     lateinit var secureStore: SecureStore
 
+    // Remove this once Secure Store is fixed
+    private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
+
     private val data = TestUtils.appInfoData
 
     @get:Rule(order = 3)
@@ -112,7 +116,7 @@ class LoginTest : TestCase() {
             })
 
         hiltRule.inject()
-        secureStore.delete(Keys.PERSISTENT_ID_KEY)
+        deletePersistentId()
     }
 
     @After
@@ -173,7 +177,7 @@ class LoginTest : TestCase() {
     @Test
     fun selectingLoginButtonFiresAuthRequestWithPersistentIdFromSecureStore() {
         runBlocking {
-            secureStore.upsert(Keys.PERSISTENT_ID_KEY, persistentId)
+            setPersistentId()
         }
         wheneverBlocking { mockAppInfoService.get() }
             .thenReturn(AppInfoServiceState.Successful(data))
@@ -385,6 +389,23 @@ class LoginTest : TestCase() {
             @Suppress("unchecked_cast")
             (it.arguments[1] as (TokenResponse) -> Unit).invoke(tokenResponse)
         }
+    }
+
+    private fun setPersistentId() {
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.upsert(
+//            key = Keys.PERSISTENT_ID_KEY,
+//            value = id
+//        )
+        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, persistentId).apply()
+    }
+
+    private fun deletePersistentId() {
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.delete(
+//            key = Keys.PERSISTENT_ID_KEY
+//        )
+        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
     }
 
     companion object {

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -22,7 +22,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.android.authentication.integrity.ClientAttestationManager
+import uk.gov.android.authentication.integrity.AppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
 import uk.gov.android.authentication.integrity.keymanager.ECKeyManager
@@ -93,7 +93,7 @@ class WelcomeScreenTest : TestCase() {
     val mockAppIntegrity: AppIntegrity = mock()
 
     @BindValue
-    val mockAttestationManager: ClientAttestationManager = mock()
+    val mockAttestationManager: AppIntegrityManager = mock()
 
     @BindValue
     val mockAttestationCaller: AttestationCaller = mock()
@@ -114,6 +114,8 @@ class WelcomeScreenTest : TestCase() {
     @Inject
     @Named("Open")
     lateinit var secureStore: SecureStore
+
+    private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
 
     private var shouldTryAgainCalled = false
     private val persistentId = "id"
@@ -459,17 +461,21 @@ class WelcomeScreenTest : TestCase() {
         verify(mockNavigator).navigate(ErrorRoutes.Offline)
     }
 
-    private suspend fun setPersistentId(id: String) {
-        secureStore.upsert(
-            key = Keys.PERSISTENT_ID_KEY,
-            value = id
-        )
+    private fun setPersistentId(id: String) {
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.upsert(
+//            key = Keys.PERSISTENT_ID_KEY,
+//            value = id
+//        )
+        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, id).apply()
     }
 
     private fun deletePersistentId() {
-        secureStore.delete(
-            key = Keys.PERSISTENT_ID_KEY
-        )
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.delete(
+//            key = Keys.PERSISTENT_ID_KEY
+//        )
+        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
     }
 
     @Test

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -115,6 +115,7 @@ class WelcomeScreenTest : TestCase() {
     @Named("Open")
     lateinit var secureStore: SecureStore
 
+    // Remove this once Secure Store is fixed
     private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
 
     private var shouldTryAgainCalled = false

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
@@ -83,6 +83,9 @@ class SignedOutInfoScreenTest : TestCase() {
     @Named("Open")
     lateinit var secureStore: SecureStore
 
+    // Remove this once Secure Store is fixed
+    private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
+
     private var shouldTryAgainCalled = false
     private val persistentId = "id"
 
@@ -96,7 +99,7 @@ class SignedOutInfoScreenTest : TestCase() {
     fun setup() = runBlocking {
         hiltRule.inject()
         shouldTryAgainCalled = false
-        setPersistentId(persistentId)
+        setPersistentId()
     }
 
     @Test
@@ -207,7 +210,7 @@ class SignedOutInfoScreenTest : TestCase() {
     fun noPersistentId_OpensSignInScreen() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
-        setPersistentId("")
+        deletePersistentId()
 
         composeTestRule.setContent {
             SignedOutInfoScreen()
@@ -341,11 +344,21 @@ class SignedOutInfoScreenTest : TestCase() {
         verify(mockNavigator).navigate(ErrorRoutes.Offline)
     }
 
-    private suspend fun setPersistentId(id: String) {
-        secureStore.upsert(
-            key = Keys.PERSISTENT_ID_KEY,
-            value = id
-        )
+    private fun setPersistentId() {
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.upsert(
+//            key = Keys.PERSISTENT_ID_KEY,
+//            value = id
+//        )
+        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, persistentId).apply()
+    }
+
+    private fun deletePersistentId() {
+        // This has been removed due to temporary Secure Store fix, change this back
+//        secureStore.delete(
+//            key = Keys.PERSISTENT_ID_KEY
+//        )
+        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
     }
 
     @Test

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -47,11 +47,9 @@ class AppIntegrityImpl @Inject constructor(
     private suspend fun handleClientAttestation(result: AttestationResponse.Success) =
         try {
             saveToOpenSecureStore.save(CLIENT_ATTESTATION, result.attestationJwt)
-            saveToOpenSecureStore
-                .save(
-                    CLIENT_ATTESTATION_EXPIRY,
-                    appCheck.getExpiry(result.attestationJwt).toString()
-                )
+            appCheck.getExpiry(result.attestationJwt)?.let {
+                saveToOpenSecureStore.save(CLIENT_ATTESTATION_EXPIRY, it)
+            }
             AttestationResult.Success
         } catch (e: SecureStorageError) {
             AttestationResult.Failure(e.message ?: SECURE_STORE_ERROR)

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.util.Log
 import io.ktor.util.date.getTimeMillis
 import javax.inject.Inject
-import uk.gov.android.authentication.integrity.ClientAttestationManager
+import uk.gov.android.authentication.integrity.AppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
 import uk.gov.android.authentication.integrity.pop.SignedPoP
 import uk.gov.android.features.FeatureFlags
@@ -20,18 +20,12 @@ import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
 class AppIntegrityImpl @Inject constructor(
     private val context: Context,
     private val featureFlags: FeatureFlags,
-    private val appCheck: ClientAttestationManager,
+    private val appCheck: AppIntegrityManager,
     private val saveToOpenSecureStore: SaveToOpenSecureStore,
     private val getFromOpenSecureStore: GetFromOpenSecureStore
 ) : AppIntegrity {
     override suspend fun getClientAttestation(): AttestationResult {
-        // This is just to not block from using the app as the Firebase Token expiry time is set for a longer time
-        // which blocks from logging back in - to solve this needs deleting the app and re-install or waiting for > 15 min
-        // Needs to be update with the proper logic on DCMAW-10441
-        val expiry: String? = getFromOpenSecureStore.invoke(
-            CLIENT_ATTESTATION_EXPIRY
-        )
-        return if (featureFlags[AppCheckFeatureFlag.ENABLED] && isAttestationExpired(expiry)) {
+        return if (isAttestationCallRequired()) {
             val result = appCheck.getAttestation()
             Log.d("AppIntegrity", "$result")
             when (result) {
@@ -52,13 +46,32 @@ class AppIntegrityImpl @Inject constructor(
 
     private suspend fun handleClientAttestation(result: AttestationResponse.Success) =
         try {
+            // Currently this is failing
             saveToOpenSecureStore.save(CLIENT_ATTESTATION, result.attestationJwt)
             saveToOpenSecureStore
-                .save(CLIENT_ATTESTATION_EXPIRY, result.expiresIn)
+                .save(
+                    CLIENT_ATTESTATION_EXPIRY,
+                    appCheck.getExpiry(result.attestationJwt).toString()
+                )
             AttestationResult.Success
         } catch (e: SecureStorageError) {
             AttestationResult.Failure(e.message ?: SECURE_STORE_ERROR)
         }
+
+    private suspend fun isAttestationCallRequired(): Boolean {
+        val expiry: String? = getFromOpenSecureStore.invoke(
+            CLIENT_ATTESTATION_EXPIRY
+        )
+        val clientAttestation: String? = getFromOpenSecureStore.invoke(
+            CLIENT_ATTESTATION
+        )
+
+        val result = isAttestationExpired(expiry) ||
+            clientAttestation == null ||
+            !appCheck.verifyAttestationJwk(clientAttestation)
+
+        return featureFlags[AppCheckFeatureFlag.ENABLED] && result
+    }
 
     private fun isAttestationExpired(expiryTime: String?): Boolean {
         return if (expiryTime != null) {

--- a/app/src/main/java/uk/gov/onelogin/appcheck/FirebaseAppCheck.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/FirebaseAppCheck.kt
@@ -27,7 +27,7 @@ class FirebaseAppCheck @Inject constructor(
     override suspend fun getAppCheckToken(): Result<AppCheckToken> {
         return try {
             Result.success(
-                AppCheckToken(appCheck.getAppCheckToken(false).await().token)
+                AppCheckToken(appCheck.limitedUseAppCheckToken.await().token)
             )
         } catch (e: FirebaseException) {
             Result.failure(e)

--- a/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AppCheckUseCaseModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AppCheckUseCaseModule.kt
@@ -7,8 +7,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ViewModelComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlin.io.encoding.ExperimentalEncodingApi
-import uk.gov.android.authentication.integrity.ClientAttestationManager
-import uk.gov.android.authentication.integrity.FirebaseClientAttestationManager
+import uk.gov.android.authentication.integrity.AppIntegrityManager
+import uk.gov.android.authentication.integrity.FirebaseAppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
 import uk.gov.android.authentication.integrity.keymanager.ECKeyManager
@@ -41,8 +41,8 @@ object AppCheckUseCaseModule {
     @Provides
     fun provideFirebaseTokenManager(
         config: AppIntegrityConfiguration
-    ): ClientAttestationManager {
-        return FirebaseClientAttestationManager(config)
+    ): AppIntegrityManager {
+        return FirebaseAppIntegrityManager(config)
     }
 
     @Provides
@@ -50,7 +50,7 @@ object AppCheckUseCaseModule {
         @ApplicationContext
         context: Context,
         featureFlags: FeatureFlags,
-        appCheck: ClientAttestationManager,
+        appCheck: AppIntegrityManager,
         saveToOpenSecureStore: SaveToOpenSecureStore,
         getFromOpenSecureStore: GetFromOpenSecureStore
     ): AppIntegrity {

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabScreen.kt
@@ -43,6 +43,22 @@ fun AppIntegrityTabScreen(
             )
         }
 
+        DataItem(
+            action1 = { viewModel.resetAttestation() },
+            action2 = { viewModel.setFakeAttestation() },
+            result = viewModel.clientAttestation,
+            buttonText1 = "Remove attestation",
+            buttonText2 = "Set fake attestation"
+        )
+
+        DataItem(
+            action1 = { viewModel.resetAttestationExpiry() },
+            action2 = { viewModel.setFutureAttestationExpiry() },
+            result = viewModel.clientAttestationExpiry,
+            buttonText1 = "Reset attestation expiry time",
+            buttonText2 = "Set expiry in future"
+        )
+
         ActionItem(
             action = { viewModel.getToken() },
             result = viewModel.tokenResponse,
@@ -81,6 +97,33 @@ private fun ActionItem(
             onClick = action
         ) {
             Text(text = buttonText)
+        }
+    }
+    Row(modifier = Modifier.padding(all = smallPadding)) {
+        Text(text = result.value)
+    }
+}
+
+@Composable
+private fun DataItem(
+    action1: () -> Unit,
+    action2: () -> Unit,
+    result: MutableState<String>,
+    buttonText1: String,
+    buttonText2: String
+) {
+    Row {
+        Button(
+            modifier = Modifier.padding(start = smallPadding).weight(1F),
+            onClick = action1
+        ) {
+            Text(text = buttonText1)
+        }
+        Button(
+            modifier = Modifier.padding(start = smallPadding).weight(1F),
+            onClick = action2
+        ) {
+            Text(text = buttonText2)
         }
     }
     Row(modifier = Modifier.padding(all = smallPadding)) {

--- a/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/developer/tabs/appintegrity/AppIntegrityTabViewModel.kt
@@ -7,14 +7,14 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import uk.gov.android.authentication.integrity.ClientAttestationManager
+import uk.gov.android.authentication.integrity.AppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.onelogin.appcheck.AppIntegrity
 
 @HiltViewModel
 class AppIntegrityTabViewModel @Inject constructor(
     private val firebaseAppCheck: AppChecker,
-    private val appCheck: ClientAttestationManager,
+    private val appCheck: AppIntegrityManager,
     private val appIntegrity: AppIntegrity
 ) : ViewModel() {
     val tokenResponse: MutableState<String> = mutableStateOf("")

--- a/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
@@ -7,7 +7,6 @@ import dagger.hilt.android.components.ViewModelComponent
 import uk.gov.onelogin.tokens.usecases.GetEmail
 import uk.gov.onelogin.tokens.usecases.GetEmailImpl
 import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStore
-import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.GetPersistentId
@@ -17,11 +16,12 @@ import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreDataImpl
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiryImpl
 import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
-import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiryImpl
+import uk.gov.onelogin.tokens.usecases.TemporaryGetFromOpenSecureStoreImpl
+import uk.gov.onelogin.tokens.usecases.TemporarySaveToOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.verifier.Jose4jJwtVerifier
 import uk.gov.onelogin.tokens.verifier.JwtVerifier
 
@@ -36,7 +36,7 @@ interface TokenModule {
 
     @Binds
     fun bindGetFromOpenSecureStore(
-        getFromOpenSecureStore: GetFromOpenSecureStoreImpl
+        getFromOpenSecureStore: TemporaryGetFromOpenSecureStoreImpl
     ): GetFromOpenSecureStore
 
     @Binds
@@ -46,7 +46,7 @@ interface TokenModule {
 
     @Binds
     fun bindSaveToOpenSecureStore(
-        saveToOpenSecureStore: SaveToOpenSecureStoreImpl
+        saveToOpenSecureStore: TemporarySaveToOpenSecureStoreImpl
     ): SaveToOpenSecureStore
 
     @Binds

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromOpenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromOpenSecureStore.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.tokens.usecases
 
+import android.content.SharedPreferences
 import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
@@ -37,5 +38,15 @@ class GetFromOpenSecureStoreImpl @Inject constructor(
             }
             is RetrievalEvent.Success -> retrievalEvent.value
         }
+    }
+}
+
+class TemporaryGetFromOpenSecureStoreImpl @Inject constructor(
+    private val sharedPrefs: SharedPreferences
+) : GetFromOpenSecureStore {
+    override suspend fun invoke(
+        key: String
+    ): String? {
+        return sharedPrefs.getString(key, null)
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.tokens.usecases
 
+import android.content.SharedPreferences
 import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
@@ -48,5 +49,17 @@ class SaveToOpenSecureStoreImpl @Inject constructor(
         } catch (e: SecureStorageError) {
             Log.e(this::class.simpleName, e.message, e)
         }
+    }
+}
+
+class TemporarySaveToOpenSecureStoreImpl @Inject constructor(
+    private val sharedPrefs: SharedPreferences
+) : SaveToOpenSecureStore {
+    override suspend fun save(key: String, value: String) {
+        sharedPrefs.edit().putString(key, value).apply()
+    }
+
+    override suspend fun save(key: String, value: Number) {
+        sharedPrefs.edit().putString(key, value.toString()).apply()
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -69,7 +69,7 @@ class AppIntegrityImplTest {
         val result = sut.getClientAttestation()
 
         verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
-        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION_EXPIRY, "100")
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION_EXPIRY, 100L)
         assertEquals(AttestationResult.Success, result)
     }
 

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -104,7 +104,7 @@ class AppIntegrityImplTest {
     fun `get client attestation - attestation stored is expired`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
         whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn("${getTimeMillis() - (getFiveMinInMillis())}")
+            .thenReturn("${(getTimeMillis() - (getFiveMinInMillis())) / 1000}")
         whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
             .thenReturn("testAttestation")
         whenever(appCheck.verifyAttestationJwk("testAttestation")).thenReturn(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.11.0" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.12.0" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }


### PR DESCRIPTION
## [DCMAW-10441](https://govukverify.atlassian.net/browse/DCMAW-10441)

### Description of changes
- Include checks on app integrity to see if saved attestation is either null;, expired or doesn't match the current public key
- Some facilitation bits added to the dev menu to show evidence

### Evidence
AC1 is not really possible to show however the screenshot below does show that when we receive a failure from making the attestation call we are directing to the `SignInError` screen
![image](https://github.com/user-attachments/assets/4b9e8950-8450-43f0-b24b-93766ab05ba4)


AC 2, 3 and 4
[DCMAW-10441.webm](https://github.com/user-attachments/assets/3516379c-de1c-4de6-a1bb-c3d68b2493c2)


[DCMAW-10441]: https://govukverify.atlassian.net/browse/DCMAW-10441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ