### PR TITLE
feat: Add AppIntegrityParameters into the authRequest header

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.wheneverBlocking
 import uk.gov.android.authentication.integrity.AppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.usecase.AppChecker
 import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
@@ -149,6 +150,8 @@ class WelcomeScreenTest : TestCase() {
     fun opensWebLoginViaCustomTab() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(false)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
 
         composeTestRule.setContent {
             WelcomeScreen()
@@ -193,6 +196,8 @@ class WelcomeScreenTest : TestCase() {
     fun opensWebLoginViaCustomTab_StsFlagOn() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
+        wheneverBlocking { mockAppIntegrity.getClientAttestation() }
+            .thenReturn(AttestationResult.Success("Success"))
         composeTestRule.setContent {
             WelcomeScreen()
         }
@@ -237,6 +242,8 @@ class WelcomeScreenTest : TestCase() {
     fun opensWebLoginViaCustomTab_StsFlagOn_goodPersistentId() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
+        wheneverBlocking { mockAppIntegrity.getClientAttestation() }
+            .thenReturn(AttestationResult.Success("Success"))
         setPersistentId(persistentId)
 
         composeTestRule.setContent {
@@ -285,6 +292,8 @@ class WelcomeScreenTest : TestCase() {
     fun opensWebLoginViaCustomTab_StsFlagOn_emptyPersistentId() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
+        wheneverBlocking { mockAppIntegrity.getClientAttestation() }
+            .thenReturn(AttestationResult.Success("Success"))
         setPersistentId("")
 
         composeTestRule.setContent {
@@ -345,6 +354,8 @@ class WelcomeScreenTest : TestCase() {
     fun loginFiresAutomaticallyIfOnlineAndShouldTryAgainIsTrue() = runBlocking {
         whenever(onlineChecker.isOnline()).thenReturn(true)
         whenever(featureFlags[StsFeatureFlag.STS_ENDPOINT]).thenReturn(true)
+        wheneverBlocking { mockAppIntegrity.getClientAttestation() }
+            .thenReturn(AttestationResult.Success("Success"))
         composeTestRule.setContent {
             WelcomeScreen(
                 shouldTryAgain = {
@@ -426,6 +437,8 @@ class WelcomeScreenTest : TestCase() {
         val context: Context = ApplicationProvider.getApplicationContext()
         val event = SignInAnalyticsViewModel.makeSignInEvent(context)
         whenever(onlineChecker.isOnline()).thenReturn(true)
+        wheneverBlocking { mockAppIntegrity.getClientAttestation() }
+            .thenReturn(AttestationResult.Success("Success"))
         composeTestRule.setContent {
             WelcomeScreen()
         }

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -10,5 +10,4 @@
     <string name="apiBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
     <string name="helloWorldUrl" translatable="false">https://hello-world.token.build.account.gov.uk%1$s</string>
     <string name="appInfoUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
-    <string name="temp" translatable="false">https://backend-api-jl.mobile.dev.account.gov.uk</string>
 </resources>

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="openIdConnectBaseUrl" translatable="false">https://auth-stub.mobile.build.account.gov.uk%1$s</string>
     <string name="stsUrl" translatable="false">https://token.build.account.gov.uk%1$s</string>
-    <string name="baseStsUrl" translatable="false">https://token.build.account.gov.uk%1$s</string>
+    <string name="baseStsUrl" translatable="false">https://token.build.account.gov.uk</string>
     <string name="openIdConnectClientId" translatable="false">TEST_CLIENT_ID</string>
     <string name="stsClientId" translatable="false">bYrcuRVvnylvEgYSSbBjwXzHrwJ</string>
     <string name="webBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>

--- a/app/src/build/res/values/login_flow.xml
+++ b/app/src/build/res/values/login_flow.xml
@@ -10,4 +10,5 @@
     <string name="apiBaseUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
     <string name="helloWorldUrl" translatable="false">https://hello-world.token.build.account.gov.uk%1$s</string>
     <string name="appInfoUrl" translatable="false">https://mobile.build.account.gov.uk%1$s</string>
+    <string name="temp" translatable="false">https://backend-api-jl.mobile.dev.account.gov.uk</string>
 </resources>

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrity.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrity.kt
@@ -5,6 +5,7 @@ import uk.gov.android.authentication.integrity.pop.SignedPoP
 interface AppIntegrity {
     suspend fun getClientAttestation(): AttestationResult
     fun getProofOfPossession(): SignedPoP
+    suspend fun retrieveSavedClientAttestation(): String?
 
     companion object {
         const val CLIENT_ATTESTATION = "appCheckClientAttestation"

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -33,8 +33,8 @@ class AppIntegrityImpl @Inject constructor(
                 is AttestationResponse.Failure -> AttestationResult.Failure(result.reason)
             }
         } else {
-            // The non-null assertion is used because this is being checked in the isAttestationCallRequired() call
-            AttestationResult.NotRequired(getFromOpenSecureStore(CLIENT_ATTESTATION)!!)
+            AttestationResult
+                .NotRequired(getFromOpenSecureStore(CLIENT_ATTESTATION) ?: "")
         }
     }
 

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -34,7 +34,7 @@ class AppIntegrityImpl @Inject constructor(
             }
         } else {
             AttestationResult
-                .NotRequired(getFromOpenSecureStore(CLIENT_ATTESTATION) ?: "")
+                .NotRequired(retrieveSavedClientAttestation() ?: "")
         }
     }
 

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -34,7 +34,7 @@ class AppIntegrityImpl @Inject constructor(
             }
         } else {
             AttestationResult
-                .NotRequired(retrieveSavedClientAttestation() ?: "")
+                .NotRequired(retrieveSavedClientAttestation())
         }
     }
 

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AttestationResult.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AttestationResult.kt
@@ -1,7 +1,7 @@
 package uk.gov.onelogin.appcheck
 
 sealed class AttestationResult {
-    data object Success : AttestationResult()
+    data class Success(val clientAttestation: String) : AttestationResult()
     data class Failure(val error: String) : AttestationResult()
-    data object NotRequired : AttestationResult()
+    data class NotRequired(val savedAttestation: String) : AttestationResult()
 }

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AttestationResult.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AttestationResult.kt
@@ -3,5 +3,5 @@ package uk.gov.onelogin.appcheck
 sealed class AttestationResult {
     data class Success(val clientAttestation: String) : AttestationResult()
     data class Failure(val error: String) : AttestationResult()
-    data class NotRequired(val savedAttestation: String) : AttestationResult()
+    data class NotRequired(val savedAttestation: String?) : AttestationResult()
 }

--- a/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
 import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
-import uk.gov.android.authentication.integrity.appcheck.usecase.JWK
+import uk.gov.android.authentication.json.jwk.JWK
 import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
@@ -17,13 +17,13 @@ class AttestationApiCall @Inject constructor(
     private val context: Context,
     private val httpClient: GenericHttpClient
 ) : AttestationCaller {
-    override suspend fun call(firebaseToken: String, jwk: JWK.JsonWebKey): AttestationResponse {
+    override suspend fun call(token: String, jwk: JWK.JsonWebKey): AttestationResponse {
         val endpoint = context.getString(R.string.clientAttestationEndpoint)
         val request = ApiRequest.Post(
             url = context.getString(R.string.webBaseUrl, endpoint) + "?device=android",
             body = jwk,
             headers = listOf(
-                AttestationCaller.FIREBASE_HEADER to firebaseToken,
+                AttestationCaller.FIREBASE_HEADER to token,
                 AttestationCaller.CONTENT_TYPE to AttestationCaller.CONTENT_TYPE_VALUE
             )
         )

--- a/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCall.kt
@@ -17,10 +17,7 @@ class AttestationApiCall @Inject constructor(
     private val context: Context,
     private val httpClient: GenericHttpClient
 ) : AttestationCaller {
-    override suspend fun call(
-        firebaseToken: String,
-        jwk: JWK.JsonWebKey
-    ): AttestationResponse {
+    override suspend fun call(firebaseToken: String, jwk: JWK.JsonWebKey): AttestationResponse {
         val endpoint = context.getString(R.string.clientAttestationEndpoint)
         val request = ApiRequest.Post(
             url = context.getString(R.string.webBaseUrl, endpoint) + "?device=android",

--- a/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
@@ -167,7 +167,7 @@ class WelcomeScreenViewModel @Inject constructor(
             is AttestationResult.NotRequired -> {
                 _loading.emit(false)
                 onSuccess(
-                    attestation.savedAttestation
+                    attestation.savedAttestation ?: ""
                 )
             }
             else -> {
@@ -180,11 +180,11 @@ class WelcomeScreenViewModel @Inject constructor(
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun handleCreatePoP(attestation: String, onSuccess: (popJwt: String) -> Unit) {
+    private fun handleCreatePoP(attestation: String, callback: (popJwt: String) -> Unit) {
         if (attestation.isNotEmpty()) {
             when (val popResult = appIntegrity.getProofOfPossession()) {
                 is SignedPoP.Success -> try {
-                    onSuccess(popResult.popJwt)
+                    callback(popResult.popJwt)
                 } catch (e: Throwable) { // handle both Error and Exception types.
                     // Includes AuthenticationError
                     Log.e(tag, e.message, e)
@@ -196,7 +196,7 @@ class WelcomeScreenViewModel @Inject constructor(
                 }
             }
         } else {
-            onSuccess("")
+            callback("")
         }
     }
 

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/VerifyIdToken.kt
@@ -116,7 +116,7 @@ fun String.extractEmailFromIdToken(): String? {
 fun String.extractPersistentIdFromIdToken(): String? {
     try {
         val bodyEncoded = this.split(".")[1]
-        val body = String(Base64.decode(bodyEncoded))
+        val body = String(Base64.withPadding(PaddingOption.ABSENT).decode(bodyEncoded))
         val data = Json.parseToJsonElement(body)
         val id = data.jsonObject["persistent_id"]
         val stripEmail = id?.toString()?.removeSurrounding("\"")

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -60,6 +60,15 @@ class AppIntegrityImplTest {
     }
 
     @Test
+    fun `get client attestation - feature flag disabled and no saved attestation`() = runBlocking {
+        whenever(featureFlags[eq(AppCheckFeatureFlag.ENABLED)]).thenReturn(false)
+        whenever(getFromOpenSecureStore(eq(CLIENT_ATTESTATION))).thenReturn(null)
+
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.NotRequired(""), result)
+    }
+
+    @Test
     fun `get client attestation - attestation call successful`() = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
         whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -1,8 +1,8 @@
 package uk.gov.onelogin.appcheck
 
 import android.content.Context
+import io.jsonwebtoken.security.SignatureException
 import io.ktor.util.date.getTimeMillis
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +14,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.integrity.AppIntegrityManager
 import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
-import uk.gov.android.authentication.integrity.keymanager.ECKeyManager
 import uk.gov.android.authentication.integrity.pop.SignedPoP
 import uk.gov.android.features.FeatureFlags
 import uk.gov.android.securestore.error.SecureStorageError
@@ -24,7 +23,6 @@ import uk.gov.onelogin.features.AppCheckFeatureFlag
 import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
 
-@OptIn(ExperimentalEncodingApi::class)
 class AppIntegrityImplTest {
     private lateinit var context: Context
     private lateinit var featureFlags: FeatureFlags
@@ -65,7 +63,7 @@ class AppIntegrityImplTest {
         whenever(getFromOpenSecureStore(eq(CLIENT_ATTESTATION))).thenReturn(null)
 
         val result = sut.getClientAttestation()
-        assertEquals(AttestationResult.NotRequired(""), result)
+        assertEquals(AttestationResult.NotRequired(null), result)
     }
 
     @Test
@@ -219,7 +217,7 @@ class AppIntegrityImplTest {
 
     @Test
     fun `generate Proof of Possession - failure`() {
-        val exp = ECKeyManager.SigningError.InvalidSignature
+        val exp = SignatureException(FAILURE)
         whenever(appCheck.generatePoP(any(), any()))
             .thenReturn(SignedPoP.Failure(exp.message!!, exp))
         whenever(context.getString(any()))

--- a/app/src/test/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCallTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/usecase/AttestationApiCallTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.integrity.appcheck.model.AttestationResponse
 import uk.gov.android.authentication.integrity.appcheck.usecase.AttestationCaller
-import uk.gov.android.authentication.integrity.appcheck.usecase.JWK
+import uk.gov.android.authentication.json.jwk.JWK
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
 
@@ -105,7 +105,7 @@ class AttestationApiCallTest {
     }
 
     companion object {
-        private val jwk = JWK.makeJWK("x", "y")
+        private val jwk = JWK.generateJwk("x", "y")
         private const val INVALID_CLIENT_ATTESTATION = "{\"client_attestation\": \"Success\", " +
             "\"expires_in\": \"a\"}"
         private const val VALID_CLIENT_ATTESTATION = "{\"client_attestation\": \"Success\", " +

--- a/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -22,6 +22,7 @@ import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.android.features.FeatureFlags
 import uk.gov.android.network.online.OnlineChecker
 import uk.gov.onelogin.appcheck.AppIntegrity
+import uk.gov.onelogin.appcheck.AttestationResult
 import uk.gov.onelogin.credentialchecker.BiometricStatus
 import uk.gov.onelogin.credentialchecker.CredentialChecker
 import uk.gov.onelogin.extensions.CoroutinesTestExtension
@@ -103,11 +104,13 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.Success("Success"))
             whenever(mockAppIntegrity.getProofOfPossession())
                 .thenReturn(SignedPoP.Success("Success"))
-            whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
                 .thenAnswer {
-                    (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                    (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
                 }
             whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
                 .thenReturn(true)
@@ -133,6 +136,8 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.NotRequired("Success"))
             whenever(mockAppIntegrity.getProofOfPossession())
                 .thenReturn(SignedPoP.Failure("Error"))
 
@@ -154,11 +159,13 @@ class WelcomeScreenViewModelTest {
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
             whenever(mockBioPrefHandler.getBioPref()).thenReturn(BiometricPreference.BIOMETRICS)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.Success("Success"))
             whenever(mockAppIntegrity.getProofOfPossession())
                 .thenReturn(SignedPoP.Success("Success"))
-            whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
                 .thenAnswer {
-                    (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                    (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
                 }
             whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
                 .thenReturn(true)
@@ -191,11 +198,13 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.Success("Success"))
             whenever(mockAppIntegrity.getProofOfPossession())
                 .thenReturn(SignedPoP.Success("Success"))
-            whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
                 .thenAnswer {
-                    (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(nullIdTokenResponse)
+                    (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(nullIdTokenResponse)
                 }
 
             viewModel.handleActivityResult(mockIntent)
@@ -217,11 +226,13 @@ class WelcomeScreenViewModelTest {
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
         whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
+        whenever(mockAppIntegrity.retrieveSavedClientAttestation())
+            .thenReturn("Success")
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenAnswer {
-                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
             }
         whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
             .thenReturn(true)
@@ -244,11 +255,13 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(mockUri)
             whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
             whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.SUCCESS)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.Success("Success"))
             whenever(mockAppIntegrity.getProofOfPossession())
                 .thenReturn(SignedPoP.Success("Success"))
-            whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+            whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
                 .thenAnswer {
-                    (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                    (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
                 }
             whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
                 .thenReturn(true)
@@ -270,11 +283,13 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(false)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenAnswer {
-                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
             }
         whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
             .thenReturn(true)
@@ -296,11 +311,13 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(false)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenAnswer {
-                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
             }
         whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
             .thenReturn(true)
@@ -322,11 +339,13 @@ class WelcomeScreenViewModelTest {
 
         whenever(mockIntent.data).thenReturn(mockUri)
         whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenAnswer {
-                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
             }
         whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
             .thenReturn(true)
@@ -360,9 +379,11 @@ class WelcomeScreenViewModelTest {
         val mockUri: Uri = mock()
 
         whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenThrow(
                 AuthenticationError(
                     "Sign in error",
@@ -386,11 +407,13 @@ class WelcomeScreenViewModelTest {
         val mockUri: Uri = mock()
 
         whenever(mockIntent.data).thenReturn(mockUri)
+        whenever(mockAppIntegrity.getClientAttestation())
+            .thenReturn(AttestationResult.Success("Success"))
         whenever(mockAppIntegrity.getProofOfPossession())
             .thenReturn(SignedPoP.Success("Success"))
-        whenever(mockLoginSession.finalise(eq(mockIntent), any()))
+        whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
             .thenAnswer {
-                (it.arguments[1] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
             }
         whenever(mockVerifyIdToken.invoke(eq("testIdToken"), eq("testUrl")))
             .thenReturn(false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "serialization" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
-org-sonarqube = { id = "org.sonarqube", version.ref = "sonarqube-gradle" }
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }
 
 [versions]
@@ -23,7 +22,6 @@ lifecycle-runtime-compose = "2.8.7"
 ktlint = "12.1.1"
 hiltPlugin = "2.52"
 detekt = "1.23.7"
-parcelize = "2.0.0"
 andoridxBrowser = "1.8.0"
 androidxBiometric = "1.1.0"
 androidxHilt = "1.2.0"
@@ -39,7 +37,6 @@ compose-material3 = "1.3.1"
 serialization = "2.0.20"
 junit = "5.11.3"
 jacoco = "0.8.12" # https://www.jacoco.org/jacoco/trunk/doc/changes.html
-sonarqube-gradle = "5.0.0.4638" # https://github.com/SonarSource/sonar-scanner-gradle/releases
 googleServices = "4.4.2"
 firebaseBom = "33.5.1"
 crashlytics = "3.0.2"
@@ -101,7 +98,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.1" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.2" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.12.0" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.0" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -101,7 +101,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.0" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.1" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }


### PR DESCRIPTION
**Ticket Link:** 
[DCMAW-10315](https://govukverify.atlassian.net/browse/DCMAW-10315)

**Description Of Changes:** 
- implement the updated finalise() method that allows for the AppIntegrityParameters - ClientAttestation and PoP - into the header of the auth request to get access tokens
- update the logic on the WelcomeScreenViewModel to allow for retry of retrieving a new attestation if the existing one cannot be accessed

**Evidence:**
**_AC1_**
Mobile Logs
```
2024-11-29 16:53:21.189  4916-4916  Authentica...Parameters uk.gov.onelogin.build                D  {OAuth-Client-Attestation=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImY2M2FlNDkxLWZjNzAtNGExNS05ZThhLTkwNWQ0OWEzZmU2ZCJ9.eyJpc3MiOiJodHRwczovL21vYmlsZS5idWlsZC5hY2NvdW50Lmdvdi51ayIsInN1YiI6ImJZcmN1UlZ2bnlsdkVnWVNTYkJqd1h6SHJ3SiIsImV4cCI6MTczMjk4NTU5NywiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6IlAtMjU2IiwieCI6IkFJVWFxYnRBMW5yX21jNEM0T3BSWGNtdlVsbXAwRFlHazZCdEdhZ2pULTlIIiwieSI6IkFObXByM3E4a3BBSmstbWtZRV9VdWNqQXA5eWUwaG5jd1Rjckw2WUpITU9CIn19fQ.WdZoQECfEyrooXknZ5jp5oJc7BDyU9mLTk0WryGtyFf7oHqYQVvDH7CLOwmgy6GzNEjkAoJc8yjzaMGZMwy69w, OAuth-Client-Attestation-PoP=eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJiWXJjdVJWdm55bHZFZ1lTU2JCandYekhyd0oiLCJhdWQiOiJodHRwczovL3Rva2VuLmJ1aWxkLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNzMyODk5MzgxLCJqdGkiOiI2MDUzODA5ZS1mYWY0LTQ5MTktODQ1YS0zZmQ5ODc5NDk0NjAifQ.MEQCICsoOto5lVEouzjdfWOtLo0rqYwlx24IkM3_3yjf8Rn7AiApCqZup7CMV8ApUPeDq83lRybo-tmP84z7xsskUc3TLQ}
```
Backend Logs
![image (1)](https://github.com/user-attachments/assets/e358dc40-fe20-4fed-a90b-9eaa5ba10cd5)


**_AC2_**
Mobile Logs
```
2024-11-29 16:52:21.275  4453-4453  Authentica...Parameters uk.gov.onelogin.build                D  {OAuth-Client-Attestation=, OAuth-Client-Attestation-PoP=}
```

Backend Logs
![image](https://github.com/user-attachments/assets/60be08a2-0f18-4e13-b8b4-18b651cd6d4a)


**_AC3_**
Mobile Logs
```
2024-11-29 16:54:01.312  4916-4916  Authentica...Parameters uk.gov.onelogin.build                D  {OAuth-Client-Attestation=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImY2M2FlNDkxLWZjNzAtNGExNS05ZThhLTkwNWQ0OWEzZmU2ZCJ9.eyJpc3MiOiJodHRwczovL21vYmlsZS5idWlsZC5hY2NvdW50Lmdvdi51ayIsInN1YiI6ImJZcmN1UlZ2bnlsdkVnWVNTYkJqd1h6SHJ3SiIsImV4cCI6MTczMjk4NTU5NywiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6IlAtMjU2IiwieCI6IkFJVWFxYnRBMW5yX21jNEM0T3BSWGNtdlVsbXAwRFlHazZCdEdhZ2pULTlIIiwieSI6IkFObXByM3E4a3BBSmstbWtZRV9VdWNqQXA5eWUwaG5jd1Rjckw2WUpITU9CIn19fQ.WdZoQECfEyrooXknZ5jp5oJc7BDyU9mLTk0WryGtyFf7oHqYQVvDH7CLOwmgy6GzNEjkAoJc8yjzaMGZMwy69w, OAuth-Client-Attestation-PoP=eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJiWXJjdVJWdm55bHZFZ1lTU2JCandYekhyd0oiLCJhdWQiOiJodHRwczovL3Rva2VuLmJ1aWxkLmFjY291bnQuZ292LnVrIiwiZXhwIjoxNzMyODk5NDIxLCJqdGkiOiIyYWY5OWNjYS0wOWZkLTQ1NGQtOTc0OC1iNTQ5NzAzZTM4YmQifQ.MEYCIQDsosA9iPTwhfrSQ871NkidsXR0PQaJa9HIYIWXz42r6QIhALARpuWDyUF3Zm4SfUZs6GdZpKvdt4cCZPZpYzuYek69}
```

Backend Logs
![image (2)](https://github.com/user-attachments/assets/64cb5e67-6387-4c78-a474-0cc0d6788322)


**Definition Of Done Checklist:**

- [x] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [x] Relevant integration and end-to-end tests are written
- [x] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [x] Sonar coverage gates met 
- [ ] If feature flagged, Feature is enabled in staging and manually tested to ensure integration




Resolves: DCMAW-10315

[DCMAW-10315]: https://govukverify.atlassian.net/browse/DCMAW-10315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ