### PR TITLE
feat: Update to the refactored secure store

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,8 +187,6 @@ dependencies {
         libs.bundles.firebase
     ).forEach(::implementation)
 
-    implementation(files("/Users/bmihaila/Development/GDS/Android/mobile-android-secure-store/app/build/outputs/aar/app-debug.aar"))
-
     implementation(libs.wallet.sdk) {
         exclude(group = "uk.gov.android", module = "network")
         exclude(group = "uk.gov.securestore", module = "app")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,8 +187,11 @@ dependencies {
         libs.bundles.firebase
     ).forEach(::implementation)
 
+    implementation(files("/Users/bmihaila/Development/GDS/Android/mobile-android-secure-store/app/build/outputs/aar/app-debug.aar"))
+
     implementation(libs.wallet.sdk) {
         exclude(group = "uk.gov.android", module = "network")
+        exclude(group = "uk.gov.securestore", module = "app")
     }
 
     listOf(

--- a/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
@@ -456,21 +456,18 @@ class LoginTest : TestCase() {
         }
     }
 
-    private fun setPersistentId() {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.upsert(
-//            key = Keys.PERSISTENT_ID_KEY,
-//            value = id
-//        )
+    private suspend fun setPersistentId() {
+        secureStore.upsert(
+            key = Keys.PERSISTENT_ID_KEY,
+            value = persistentId
+        )
         sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, persistentId).apply()
     }
 
     private fun deletePersistentId() {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.delete(
-//            key = Keys.PERSISTENT_ID_KEY
-//        )
-        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
+        secureStore.delete(
+            key = Keys.PERSISTENT_ID_KEY
+        )
     }
 
     companion object {

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -475,21 +475,17 @@ class WelcomeScreenTest : TestCase() {
         verify(mockNavigator).navigate(ErrorRoutes.Offline)
     }
 
-    private fun setPersistentId(id: String) {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.upsert(
-//            key = Keys.PERSISTENT_ID_KEY,
-//            value = id
-//        )
-        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, id).apply()
+    private suspend fun setPersistentId(id: String) {
+        secureStore.upsert(
+            key = Keys.PERSISTENT_ID_KEY,
+            value = id
+        )
     }
 
     private fun deletePersistentId() {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.delete(
-//            key = Keys.PERSISTENT_ID_KEY
-//        )
-        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
+        secureStore.delete(
+            key = Keys.PERSISTENT_ID_KEY
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenTest.kt
@@ -116,9 +116,6 @@ class WelcomeScreenTest : TestCase() {
     @Named("Open")
     lateinit var secureStore: SecureStore
 
-    // Remove this once Secure Store is fixed
-    private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
-
     private var shouldTryAgainCalled = false
     private val persistentId = "id"
 

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
@@ -389,21 +389,17 @@ class SignedOutInfoScreenTest : TestCase() {
         verify(mockNavigator).navigate(ErrorRoutes.Offline)
     }
 
-    private fun setPersistentId() {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.upsert(
-//            key = Keys.PERSISTENT_ID_KEY,
-//            value = id
-//        )
-        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, persistentId).apply()
+    private suspend fun setPersistentId() {
+        secureStore.upsert(
+            key = Keys.PERSISTENT_ID_KEY,
+            value = persistentId
+        )
     }
 
     private fun deletePersistentId() {
-        // This has been removed due to temporary Secure Store fix, change this back
-//        secureStore.delete(
-//            key = Keys.PERSISTENT_ID_KEY
-//        )
-        sharedPrefs.edit().remove(Keys.PERSISTENT_ID_KEY).apply()
+        secureStore.delete(
+            key = Keys.PERSISTENT_ID_KEY
+        )
     }
 
     @Test

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreenTest.kt
@@ -120,9 +120,6 @@ class SignedOutInfoScreenTest : TestCase() {
     @Named("Open")
     lateinit var secureStore: SecureStore
 
-    // Remove this once Secure Store is fixed
-    private val sharedPrefs = context.getSharedPreferences("SharedPrefs.key", Context.MODE_PRIVATE)
-
     private var shouldTryAgainCalled = false
     private val persistentId = "id"
 

--- a/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
@@ -7,7 +7,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
+import org.mockito.kotlin.anyVararg
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.RetrievalEvent
@@ -30,15 +30,7 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithGeneral() = runTest {
-        val result = RetrievalEvent.Failed(SecureStoreErrorType.GENERAL)
-
-        whenever(
-            mockSecureStore.retrieveWithAuthentication(
-                any(),
-                authPromptConfig = any(),
-                context = any()
-            )
-        ).thenReturn(result)
+        mockSecureStore(RetrievalEvent.Failed(SecureStoreErrorType.GENERAL))
 
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
@@ -50,15 +42,8 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithUserCancelled() = runTest {
-        val result = RetrievalEvent.Failed(SecureStoreErrorType.USER_CANCELED_BIO_PROMPT)
+        mockSecureStore(RetrievalEvent.Failed(SecureStoreErrorType.USER_CANCELED_BIO_PROMPT))
 
-        whenever(
-            mockSecureStore.retrieveWithAuthentication(
-                any(),
-                authPromptConfig = any(),
-                context = any()
-            )
-        ).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -69,15 +54,7 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithBioFailed() = runTest {
-        val result = RetrievalEvent.Failed(SecureStoreErrorType.FAILED_BIO_PROMPT)
-
-        whenever(
-            mockSecureStore.retrieveWithAuthentication(
-                any(),
-                authPromptConfig = any(),
-                context = any()
-            )
-        ).thenReturn(result)
+        mockSecureStore(RetrievalEvent.Failed(SecureStoreErrorType.FAILED_BIO_PROMPT))
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -91,20 +68,24 @@ class GetFromTokenSecureStoreTest : TestCase() {
         val expectedKey = "expectedKey"
         val expectedValue = "expectedValue"
         val expectedResult = mapOf(expectedKey to expectedValue)
-        val result = RetrievalEvent.Success(expectedResult)
+        mockSecureStore(RetrievalEvent.Success(expectedResult))
 
-        whenever(
-            mockSecureStore.retrieveWithAuthentication(
-                eq(expectedKey),
-                authPromptConfig = any(),
-                context = any()
-            )
-        ).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
-            expectedStoreKey
+            expectedStoreKey,
+            "test"
         ) {
             assertEquals(LocalAuthStatus.Success(expectedResult), it)
         }
+    }
+
+    private suspend fun mockSecureStore(returnResult: RetrievalEvent) {
+        whenever(
+            mockSecureStore.retrieveWithAuthentication(
+                anyVararg(),
+                authPromptConfig = any(),
+                context = any()
+            )
+        ).thenReturn(returnResult)
     }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
@@ -91,7 +91,7 @@ class GetFromTokenSecureStoreTest : TestCase() {
         val expectedKey = "expectedKey"
         val expectedValue = "expectedValue"
         val expectedResult = mapOf(expectedKey to expectedValue)
-        val flow = RetrievalEvent.Success(expectedResult)
+        val result = RetrievalEvent.Success(expectedResult)
 
         whenever(
             mockSecureStore.retrieveWithAuthentication(
@@ -99,7 +99,7 @@ class GetFromTokenSecureStoreTest : TestCase() {
                 authPromptConfig = any(),
                 context = any()
             )
-        ).thenReturn(flow)
+        ).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey

--- a/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
@@ -2,12 +2,12 @@ package uk.gov.onelogin.tokens.usecases
 
 import androidx.fragment.app.FragmentActivity
 import dagger.hilt.android.testing.HiltAndroidTest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.RetrievalEvent
@@ -30,10 +30,14 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithGeneral() = runTest {
-        val flow = flow {
-            emit(RetrievalEvent.Failed(SecureStoreErrorType.GENERAL))
-        }
-        whenever(mockSecureStore.retrieveWithAuthentication(any(), any(), any())).thenReturn(flow)
+        val result = RetrievalEvent.Failed(SecureStoreErrorType.GENERAL)
+
+        whenever(mockSecureStore.retrieveWithAuthentication(
+            any(),
+            authPromptConfig = any(),
+            context = any()
+        )).thenReturn(result)
+
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -44,10 +48,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithUserCancelled() = runTest {
-        val flow = flow {
-            emit(RetrievalEvent.Failed(SecureStoreErrorType.USER_CANCELED_BIO_PROMPT))
-        }
-        whenever(mockSecureStore.retrieveWithAuthentication(any(), any(), any())).thenReturn(flow)
+        val result = RetrievalEvent.Failed(SecureStoreErrorType.USER_CANCELED_BIO_PROMPT)
+
+        whenever(mockSecureStore.retrieveWithAuthentication(
+            any(),
+            authPromptConfig = any(),
+            context = any()
+        )).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -58,10 +65,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun secureStoreFailsWithBioFailed() = runTest {
-        val flow = flow {
-            emit(RetrievalEvent.Failed(SecureStoreErrorType.FAILED_BIO_PROMPT))
-        }
-        whenever(mockSecureStore.retrieveWithAuthentication(any(), any(), any())).thenReturn(flow)
+        val result = RetrievalEvent.Failed(SecureStoreErrorType.FAILED_BIO_PROMPT)
+
+        whenever(mockSecureStore.retrieveWithAuthentication(
+            any(),
+            authPromptConfig = any(),
+            context = any()
+        )).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -72,16 +82,21 @@ class GetFromTokenSecureStoreTest : TestCase() {
 
     @Test
     fun success() = runTest {
+        val expectedKey = "expectedKey"
         val expectedValue = "expectedValue"
-        val flow = flow {
-            emit(RetrievalEvent.Success(expectedValue))
-        }
-        whenever(mockSecureStore.retrieveWithAuthentication(any(), any(), any())).thenReturn(flow)
+        val expectedResult = mapOf(expectedKey to expectedValue)
+        val flow = RetrievalEvent.Success(expectedResult)
+
+        whenever(mockSecureStore.retrieveWithAuthentication(
+            eq(expectedKey),
+            authPromptConfig = any(),
+            context = any()
+        )).thenReturn(flow)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
         ) {
-            assertEquals(LocalAuthStatus.Success(expectedValue), it)
+            assertEquals(LocalAuthStatus.Success(expectedResult), it)
         }
     }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStoreTest.kt
@@ -32,11 +32,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
     fun secureStoreFailsWithGeneral() = runTest {
         val result = RetrievalEvent.Failed(SecureStoreErrorType.GENERAL)
 
-        whenever(mockSecureStore.retrieveWithAuthentication(
-            any(),
-            authPromptConfig = any(),
-            context = any()
-        )).thenReturn(result)
+        whenever(
+            mockSecureStore.retrieveWithAuthentication(
+                any(),
+                authPromptConfig = any(),
+                context = any()
+            )
+        ).thenReturn(result)
 
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
@@ -50,11 +52,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
     fun secureStoreFailsWithUserCancelled() = runTest {
         val result = RetrievalEvent.Failed(SecureStoreErrorType.USER_CANCELED_BIO_PROMPT)
 
-        whenever(mockSecureStore.retrieveWithAuthentication(
-            any(),
-            authPromptConfig = any(),
-            context = any()
-        )).thenReturn(result)
+        whenever(
+            mockSecureStore.retrieveWithAuthentication(
+                any(),
+                authPromptConfig = any(),
+                context = any()
+            )
+        ).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -67,11 +71,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
     fun secureStoreFailsWithBioFailed() = runTest {
         val result = RetrievalEvent.Failed(SecureStoreErrorType.FAILED_BIO_PROMPT)
 
-        whenever(mockSecureStore.retrieveWithAuthentication(
-            any(),
-            authPromptConfig = any(),
-            context = any()
-        )).thenReturn(result)
+        whenever(
+            mockSecureStore.retrieveWithAuthentication(
+                any(),
+                authPromptConfig = any(),
+                context = any()
+            )
+        ).thenReturn(result)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey
@@ -87,11 +93,13 @@ class GetFromTokenSecureStoreTest : TestCase() {
         val expectedResult = mapOf(expectedKey to expectedValue)
         val flow = RetrievalEvent.Success(expectedResult)
 
-        whenever(mockSecureStore.retrieveWithAuthentication(
-            eq(expectedKey),
-            authPromptConfig = any(),
-            context = any()
-        )).thenReturn(flow)
+        whenever(
+            mockSecureStore.retrieveWithAuthentication(
+                eq(expectedKey),
+                authPromptConfig = any(),
+                context = any()
+            )
+        ).thenReturn(flow)
         useCase.invoke(
             composeTestRule.activity as FragmentActivity,
             expectedStoreKey

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -46,7 +46,7 @@ class AppIntegrityImpl @Inject constructor(
     }
 
     override suspend fun retrieveSavedClientAttestation(): String? {
-        return getFromOpenSecureStore.invoke(CLIENT_ATTESTATION)
+        return getFromOpenSecureStore.invoke(CLIENT_ATTESTATION)?.get(CLIENT_ATTESTATION)
     }
 
     private suspend fun handleClientAttestation(result: AttestationResponse.Success) =
@@ -61,16 +61,16 @@ class AppIntegrityImpl @Inject constructor(
         }
 
     private suspend fun isAttestationCallRequired(): Boolean {
-        val expiry: String? = getFromOpenSecureStore.invoke(
-            CLIENT_ATTESTATION_EXPIRY
-        )
-        val clientAttestation: String? = getFromOpenSecureStore.invoke(
+        val ssResult: Map<String, String>? = getFromOpenSecureStore.invoke(
+            CLIENT_ATTESTATION_EXPIRY,
             CLIENT_ATTESTATION
         )
+        val exp = ssResult?.get(CLIENT_ATTESTATION_EXPIRY)
+        val attestation = ssResult?.get(CLIENT_ATTESTATION)
 
-        val result = isAttestationExpired(expiry) ||
-            clientAttestation.isNullOrEmpty() ||
-            !appCheck.verifyAttestationJwk(clientAttestation)
+        val result = isAttestationExpired(exp) ||
+            attestation.isNullOrEmpty() ||
+            !appCheck.verifyAttestationJwk(attestation)
 
         return featureFlags[AppCheckFeatureFlag.ENABLED] && result
     }

--- a/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
+++ b/app/src/main/java/uk/gov/onelogin/appcheck/AppIntegrityImpl.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.appcheck
 
 import android.content.Context
-import android.util.Log
 import io.ktor.util.date.getTimeMillis
 import javax.inject.Inject
 import uk.gov.android.authentication.integrity.AppIntegrityManager
@@ -27,7 +26,6 @@ class AppIntegrityImpl @Inject constructor(
     override suspend fun getClientAttestation(): AttestationResult {
         return if (isAttestationCallRequired()) {
             val result = appCheck.getAttestation()
-            Log.d("AppIntegrity", "$result")
             when (result) {
                 is AttestationResponse.Success -> handleClientAttestation(result)
                 is AttestationResponse.Failure -> AttestationResult.Failure(result.reason)

--- a/app/src/main/java/uk/gov/onelogin/login/state/LocalAuthStatus.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/state/LocalAuthStatus.kt
@@ -2,7 +2,7 @@ package uk.gov.onelogin.login.state
 
 sealed class LocalAuthStatus {
     data class Success(
-        val payload: String
+        val payload: Map<String, String>
     ) : LocalAuthStatus()
     data object UserCancelled : LocalAuthStatus()
     data object BioCheckFailed : LocalAuthStatus()

--- a/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModel.kt
@@ -214,13 +214,11 @@ class WelcomeScreenViewModel @Inject constructor(
             context.getString(R.string.jwksEndpoint)
         )
 
-        return tokens.idToken?.let { idToken ->
-            if (!verifyIdToken(idToken, jwksUrl)) {
-                navigator.navigate(LoginRoutes.SignInError, true)
-            } else {
-                checkLocalAuthRoute(tokens, isReAuth)
-            }
-        } ?: checkLocalAuthRoute(tokens, isReAuth)
+        if (!verifyIdToken(tokens.idToken, jwksUrl)) {
+            navigator.navigate(LoginRoutes.SignInError, true)
+        } else {
+            checkLocalAuthRoute(tokens, isReAuth)
+        }
     }
 
     private suspend fun checkLocalAuthRoute(tokens: TokenResponse, isReAuth: Boolean) {

--- a/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/TokenModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.components.ViewModelComponent
 import uk.gov.onelogin.tokens.usecases.GetEmail
 import uk.gov.onelogin.tokens.usecases.GetEmailImpl
 import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStore
+import uk.gov.onelogin.tokens.usecases.GetFromOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.GetPersistentId
@@ -16,12 +17,11 @@ import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreDataImpl
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiryImpl
 import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStore
+import uk.gov.onelogin.tokens.usecases.SaveToOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStore
 import uk.gov.onelogin.tokens.usecases.SaveToSecureStoreImpl
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiry
 import uk.gov.onelogin.tokens.usecases.SaveTokenExpiryImpl
-import uk.gov.onelogin.tokens.usecases.TemporaryGetFromOpenSecureStoreImpl
-import uk.gov.onelogin.tokens.usecases.TemporarySaveToOpenSecureStoreImpl
 import uk.gov.onelogin.tokens.verifier.Jose4jJwtVerifier
 import uk.gov.onelogin.tokens.verifier.JwtVerifier
 
@@ -36,7 +36,7 @@ interface TokenModule {
 
     @Binds
     fun bindGetFromOpenSecureStore(
-        getFromOpenSecureStore: TemporaryGetFromOpenSecureStoreImpl
+        getFromOpenSecureStore: GetFromOpenSecureStoreImpl
     ): GetFromOpenSecureStore
 
     @Binds
@@ -46,7 +46,7 @@ interface TokenModule {
 
     @Binds
     fun bindSaveToOpenSecureStore(
-        saveToOpenSecureStore: TemporarySaveToOpenSecureStoreImpl
+        saveToOpenSecureStore: SaveToOpenSecureStoreImpl
     ): SaveToOpenSecureStore
 
     @Binds

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromOpenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromOpenSecureStore.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.tokens.usecases
 
-import android.content.SharedPreferences
 import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
@@ -11,13 +10,13 @@ fun interface GetFromOpenSecureStore {
     /**
      * Use case for getting data from an open secure store instance.
      *
-     * @param key [String] value of key value pair to retrieve
-     * @return The saved [String] is returned unless there is an issue or the key does not exist,
-     * in which case, null is returned
+     * @param key [String] value of key value pair/ pairs to retrieve
+     * @return The saved [String]s correlating to each key requested are returned unless there is
+     * an issue or one of the keys requested does not exist, in which case, null is returned
      */
     suspend operator fun invoke(
-        key: String
-    ): String?
+        vararg key: String
+    ): Map<String, String>?
 }
 
 class GetFromOpenSecureStoreImpl @Inject constructor(
@@ -25,28 +24,14 @@ class GetFromOpenSecureStoreImpl @Inject constructor(
     private val secureStore: SecureStore
 ) : GetFromOpenSecureStore {
     override suspend fun invoke(
-        key: String
-    ): String? {
-        val retrievalEvent = secureStore.retrieve(
-            key = key
-        )
-
-        return when (retrievalEvent) {
+        vararg key: String
+    ): Map<String, String>? {
+        return when (val retrievalEvent = secureStore.retrieve(*key)) {
             is RetrievalEvent.Failed -> {
                 Log.e(this::class.simpleName, "Reason: ${retrievalEvent.reason}")
                 null
             }
             is RetrievalEvent.Success -> retrievalEvent.value
         }
-    }
-}
-
-class TemporaryGetFromOpenSecureStoreImpl @Inject constructor(
-    private val sharedPrefs: SharedPreferences
-) : GetFromOpenSecureStore {
-    override suspend fun invoke(
-        key: String
-    ): String? {
-        return sharedPrefs.getString(key, null)
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
@@ -43,6 +43,7 @@ class GetFromTokenSecureStoreImpl @Inject constructor(
             authPromptConfig = authPromptConfig,
             context = context
         )
+
         when (result) {
             is RetrievalEvent.Success -> callback(LocalAuthStatus.Success(result.value))
 

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetFromTokenSecureStore.kt
@@ -16,7 +16,7 @@ fun interface GetFromTokenSecureStore {
      *
      * @param context Must be a FragmentActivity context (due to authentication prompt)
      * @param key [String] value of key value pairs to retrieve
-     * @return [RetrievalEvent] which is used for handling [LocalAuth]
+     * @param callback which is used for handling [LocalAuthStatus] result
      */
     suspend operator fun invoke(
         context: FragmentActivity,
@@ -58,9 +58,6 @@ class GetFromTokenSecureStoreImpl @Inject constructor(
                 }
                 callback(localAuthStatus)
             }
-
-            // Solves kotlin.NoWhenBranchMatchedException that is thrown without the else branch
-            else -> {}
         }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/GetPersistentId.kt
@@ -16,5 +16,7 @@ fun interface GetPersistentId {
 class GetPersistentIdImpl @Inject constructor(
     val getFromOpenSecureStore: GetFromOpenSecureStore
 ) : GetPersistentId {
-    override suspend fun invoke() = getFromOpenSecureStore(Keys.PERSISTENT_ID_KEY)
+    override suspend fun invoke(): String? {
+        return getFromOpenSecureStore(Keys.PERSISTENT_ID_KEY)?.get(Keys.PERSISTENT_ID_KEY)
+    }
 }

--- a/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
+++ b/app/src/main/java/uk/gov/onelogin/tokens/usecases/SaveToOpenSecureStore.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.tokens.usecases
 
-import android.content.SharedPreferences
 import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
@@ -49,17 +48,5 @@ class SaveToOpenSecureStoreImpl @Inject constructor(
         } catch (e: SecureStorageError) {
             Log.e(this::class.simpleName, e.message, e)
         }
-    }
-}
-
-class TemporarySaveToOpenSecureStoreImpl @Inject constructor(
-    private val sharedPrefs: SharedPreferences
-) : SaveToOpenSecureStore {
-    override suspend fun save(key: String, value: String) {
-        sharedPrefs.edit().putString(key, value).apply()
-    }
-
-    override suspend fun save(key: String, value: Number) {
-        sharedPrefs.edit().putString(key, value.toString()).apply()
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
@@ -34,7 +34,7 @@ class MainActivityViewModelTest {
     private val mockNavigator: Navigator = mock()
 
     private val testAccessToken = "testAccessToken"
-    private var testIdToken: String? = "testIdToken"
+    private var testIdToken: String = "testIdToken"
     private val tokenResponse = TokenResponse(
         "testType",
         testAccessToken,

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -52,6 +52,12 @@ class AppIntegrityImplTest {
     fun `get client attestation - feature flag disabled`() = runBlocking {
         whenever(featureFlags[eq(AppCheckFeatureFlag.ENABLED)]).thenReturn(false)
         whenever(getFromOpenSecureStore(CLIENT_ATTESTATION)).thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(validAttestationExpSSResult)
 
         val result = sut.getClientAttestation()
         assertEquals(AttestationResult.NotRequired(ATTESTATION), result)
@@ -61,6 +67,12 @@ class AppIntegrityImplTest {
     fun `get client attestation - feature flag disabled and no saved attestation`() = runBlocking {
         whenever(featureFlags[eq(AppCheckFeatureFlag.ENABLED)]).thenReturn(false)
         whenever(getFromOpenSecureStore(eq(CLIENT_ATTESTATION))).thenReturn(null)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(validAttestationExpSSResult)
 
         val result = sut.getClientAttestation()
         assertEquals(AttestationResult.NotRequired(null), result)
@@ -69,10 +81,12 @@ class AppIntegrityImplTest {
     @Test
     fun `get client attestation - attestation call successful`() = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(mapOf())
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(validAttestationExpSSResult)
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(false)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
@@ -87,10 +101,13 @@ class AppIntegrityImplTest {
     @Test
     fun `get client attestation - attestation already stored in secure store`() = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(validAttestationExpSSResult)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(attestationSsResult)
+        whenever(getFromOpenSecureStore(CLIENT_ATTESTATION)).thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(validAttestationExpSSResult)
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         val result = sut.getClientAttestation()
         assertEquals(AttestationResult.NotRequired(ATTESTATION), result)
@@ -100,85 +117,112 @@ class AppIntegrityImplTest {
     fun `get client attestation - saved attestation does not match saved jwks`(): Unit =
         runBlocking {
             whenever(featureFlags[any()]).thenReturn(true)
-            whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-                .thenReturn(validAttestationExpSSResult)
-            whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-                .thenReturn(attestationSsResult)
+            whenever(
+                getFromOpenSecureStore.invoke(
+                    CLIENT_ATTESTATION_EXPIRY,
+                    CLIENT_ATTESTATION
+                )
+            ).thenReturn(validAttestationExpSSResult)
             whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(false)
             whenever(appCheck.getAttestation())
                 .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-            sut.getClientAttestation()
-            verify(appCheck).getAttestation()
+            val result = sut.getClientAttestation()
+            assertEquals(AttestationResult.Success(SUCCESS), result)
         }
 
     @Test
     fun `get client attestation - attestation stored is expired`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(invalidAttestationExpSSResult)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(invalidAttestationExpSSResult)
+        println(invalidAttestationExpSSResult)
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-        sut.getClientAttestation()
-        verify(appCheck).getAttestation()
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
     @Test
     fun `get client attestation - attestation expiry time is null`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(null)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(mapOf(CLIENT_ATTESTATION to ATTESTATION))
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-        sut.getClientAttestation()
-        verify(appCheck).getAttestation()
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
     @Test
     fun `get client attestation - attestation expiry time is empty`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(mapOf(CLIENT_ATTESTATION_EXPIRY to ""))
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(attestationSsResult)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(
+            mapOf(
+                CLIENT_ATTESTATION_EXPIRY to "",
+                CLIENT_ATTESTATION to ATTESTATION
+            )
+        )
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-        sut.getClientAttestation()
-        verify(appCheck).getAttestation()
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
     @Test
     fun `get client attestation - attestation is not stored`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(validAttestationExpSSResult)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(null)
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(
+            mapOf(
+                CLIENT_ATTESTATION_EXPIRY to VALID_ATTESTATION_EXP
+            )
+        )
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-        sut.getClientAttestation()
-        verify(appCheck).getAttestation()
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
     @Test
     fun `get client attestation - saved attestation is empty`(): Unit = runBlocking {
         whenever(featureFlags[any()]).thenReturn(true)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY))
-            .thenReturn(validAttestationExpSSResult)
-        whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
-            .thenReturn(mapOf(CLIENT_ATTESTATION to ""))
+        whenever(
+            getFromOpenSecureStore.invoke(
+                CLIENT_ATTESTATION_EXPIRY,
+                CLIENT_ATTESTATION
+            )
+        ).thenReturn(
+            mapOf(
+                CLIENT_ATTESTATION_EXPIRY to VALID_ATTESTATION_EXP,
+                CLIENT_ATTESTATION to ""
+            )
+        )
         whenever(appCheck.verifyAttestationJwk(ATTESTATION)).thenReturn(true)
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
-        sut.getClientAttestation()
-        verify(appCheck).getAttestation()
+        val result = sut.getClientAttestation()
+        assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
     @Test
@@ -241,13 +285,15 @@ class AppIntegrityImplTest {
         private const val FAILURE = "Failure"
         private const val ATTESTATION = "testAttestation"
         private val attestationSsResult = mapOf(CLIENT_ATTESTATION to ATTESTATION)
-        private val VALID_ATTESTATION_EXP = "${getTimeMillis() + (getFiveMinInMillis())}"
+        private val VALID_ATTESTATION_EXP = "${(getTimeMillis() + getFiveMinInMillis()) / 1000}"
+        private val INVALID_ATTESTATION_EXP = "${(getTimeMillis() - (getFiveMinInMillis())) / 1000}"
         private val validAttestationExpSSResult = mapOf(
-            CLIENT_ATTESTATION_EXPIRY to VALID_ATTESTATION_EXP
+            CLIENT_ATTESTATION_EXPIRY to VALID_ATTESTATION_EXP,
+            CLIENT_ATTESTATION to ATTESTATION
         )
-        private val INVALID_ATTESTATION_EXP = "${getTimeMillis() - (getFiveMinInMillis())}"
         private val invalidAttestationExpSSResult = mapOf(
-            CLIENT_ATTESTATION_EXPIRY to INVALID_ATTESTATION_EXP
+            CLIENT_ATTESTATION_EXPIRY to INVALID_ATTESTATION_EXP,
+            CLIENT_ATTESTATION to ATTESTATION
         )
 
         private fun getFiveMinInMillis(): Int {

--- a/app/src/test/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
@@ -78,7 +78,7 @@ class SplashScreenViewModelTest {
         whenever(mockHandleLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
-                    LocalAuthStatus.Success("token")
+                    LocalAuthStatus.Success(mapOf("key" to "token"))
                 )
             }
         viewModel.login(mockActivity)

--- a/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -61,7 +61,7 @@ class WelcomeScreenViewModelTest {
     private val mockAppIntegrity: AppIntegrity = mock()
 
     private val testAccessToken = "testAccessToken"
-    private var testIdToken: String? = "testIdToken"
+    private var testIdToken: String = "testIdToken"
     private val tokenResponse = TokenResponse(
         "testType",
         testAccessToken,
@@ -209,41 +209,6 @@ class WelcomeScreenViewModelTest {
             verify(mockTokenRepository).setTokenResponse(tokenResponse)
             verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
             verify(mockBioPrefHandler, times(0)).setBioPref(any())
-            verify(mockAutoInitialiseSecureStore, times(1)).invoke()
-            verify(mockNavigator).navigate(MainNavRoutes.Start, true)
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    @Test
-    fun `handleIntent when data != null, device secure, no biometrics, id token is null`() =
-        runTest {
-            val mockIntent: Intent = mock()
-            val mockUri: Uri = mock()
-            val nullIdTokenResponse = TokenResponse(
-                tokenType = "testType",
-                accessToken = testAccessToken,
-                accessTokenExpirationTime = 1L,
-                refreshToken = "testRefreshToken"
-            )
-
-            whenever(mockIntent.data).thenReturn(mockUri)
-            whenever(mockCredChecker.isDeviceSecure()).thenReturn(true)
-            whenever(mockCredChecker.biometricStatus()).thenReturn(BiometricStatus.UNKNOWN)
-            whenever(mockAppIntegrity.getClientAttestation())
-                .thenReturn(AttestationResult.Success("Success"))
-            whenever(mockAppIntegrity.getProofOfPossession())
-                .thenReturn(SignedPoP.Success("Success"))
-            whenever(mockLoginSession.finalise(eq(mockIntent), any(), any()))
-                .thenAnswer {
-                    (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(nullIdTokenResponse)
-                }
-
-            viewModel.handleActivityResult(mockIntent)
-
-            verify(mockSaveTokens).invoke()
-            verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
-            verify(mockTokenRepository).setTokenResponse(nullIdTokenResponse)
-            verify(mockBioPrefHandler).setBioPref(BiometricPreference.PASSCODE)
             verify(mockAutoInitialiseSecureStore, times(1)).invoke()
             verify(mockNavigator).navigate(MainNavRoutes.Start, true)
         }

--- a/app/src/test/java/uk/gov/onelogin/login/usecase/SaveTokensTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/usecase/SaveTokensTest.kt
@@ -97,7 +97,8 @@ class SaveTokensTest {
         val testResponse = TokenResponse(
             tokenType = "test",
             accessToken = "test",
-            accessTokenExpirationTime = 1L
+            accessTokenExpirationTime = 1L,
+            idToken = "test"
         )
 
         runBlocking {

--- a/app/src/test/java/uk/gov/onelogin/network/StsAuthenticationProviderTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/network/StsAuthenticationProviderTest.kt
@@ -43,7 +43,8 @@ class StsAuthenticationProviderTest {
             TokenResponse(
                 tokenType = "type",
                 accessToken = "accessToken",
-                accessTokenExpirationTime = 1L
+                accessTokenExpirationTime = 1L,
+                idToken = "idToken"
             )
         )
 
@@ -63,7 +64,8 @@ class StsAuthenticationProviderTest {
             TokenResponse(
                 tokenType = "type",
                 accessToken = "accessToken",
-                accessTokenExpirationTime = 1L
+                accessTokenExpirationTime = 1L,
+                idToken = "idToken"
             )
         )
 
@@ -79,7 +81,8 @@ class StsAuthenticationProviderTest {
             TokenResponse(
                 tokenType = "type",
                 accessToken = "accessToken",
-                accessTokenExpirationTime = 1L
+                accessTokenExpirationTime = 1L,
+                idToken = "idToken"
             )
         )
 
@@ -111,7 +114,8 @@ class StsAuthenticationProviderTest {
             TokenResponse(
                 tokenType = "type",
                 accessToken = "accessToken",
-                accessTokenExpirationTime = 1L
+                accessTokenExpirationTime = 1L,
+                idToken = "idToken"
             )
         )
 

--- a/app/src/test/java/uk/gov/onelogin/repostiories/TokenRepositoryTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/repostiories/TokenRepositoryTest.kt
@@ -21,7 +21,8 @@ class TokenRepositoryTest {
         val testResponse = TokenResponse(
             tokenType = "test",
             accessToken = "test",
-            accessTokenExpirationTime = 1L
+            accessTokenExpirationTime = 1L,
+            idToken = "test"
         )
         repo.setTokenResponse(testResponse)
 
@@ -39,7 +40,8 @@ class TokenRepositoryTest {
         val testResponse = TokenResponse(
             tokenType = "test",
             accessToken = "test",
-            accessTokenExpirationTime = 1L
+            accessTokenExpirationTime = 1L,
+            idToken = "test"
         )
         repo.setTokenResponse(testResponse)
 

--- a/app/src/test/java/uk/gov/onelogin/tokens/usecases/GetPersistentIdImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/tokens/usecases/GetPersistentIdImplTest.kt
@@ -4,8 +4,8 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.onelogin.tokens.Keys
 
@@ -17,7 +17,8 @@ class GetPersistentIdImplTest {
 
     @Test
     fun successScenario() = runTest {
-        whenever(mockGetFromOpenSecureStore.invoke(any())).thenReturn(expectedPersistentId)
+        whenever(mockGetFromOpenSecureStore.invoke(ArgumentMatchers.any()))
+            .thenReturn(mapOf(Keys.PERSISTENT_ID_KEY to expectedPersistentId))
 
         val idResponse = sut.invoke()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -98,8 +98,8 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.2" }
-#secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.4" }
+secure-store = { group = "uk.gov.securestore", name = "app", version = "0.8.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
 
@@ -112,4 +112,4 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 
 [bundles]
 firebase = ["firebase-appcheck", "firebase-appcheck-debug", "firebase-analytics", "firebase-crashlytics"]
-gov-uk = ["components", "pages", "theme", "authentication", "network", "logging"]
+gov-uk = ["components", "pages", "theme", "authentication", "secure-store", "network", "logging"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ components = { group = "uk.gov.android", name = "components", version.ref = "gov
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
 authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.13.2" }
-secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
+#secure-store = { group = "uk.gov.securestore", name = "app", version = "0.6.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.2.8" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
 
@@ -112,4 +112,4 @@ firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashly
 
 [bundles]
 firebase = ["firebase-appcheck", "firebase-appcheck-debug", "firebase-analytics", "firebase-crashlytics"]
-gov-uk = ["components", "pages", "theme", "authentication", "secure-store", "network", "logging"]
+gov-uk = ["components", "pages", "theme", "authentication", "network", "logging"]


### PR DESCRIPTION
[DCMAW-9701](https://govukverify.atlassian.net/browse/DCMAW-9701)

- update secure store and authentication versions
- update the relevant modules to now use the secure store again (`AppIntegrity` and Tokens and `HandleLogin`) and remove temporary use of `SharedPrefs`
- secure store returns a Map<String, String> which needs to be
handled approriately for each use case
- update tests


https://github.com/user-attachments/assets/d219b505-84b8-4907-b858-5926db2a329f



[DCMAW-9701]: https://govukverify.atlassian.net/browse/DCMAW-9701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ