### PR TITLE
Feat: DCMAW 9823 App unavailable page

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableBodyTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableBodyTest.kt
@@ -1,0 +1,42 @@
+package uk.gov.onelogin.feature.unavailable.ui
+
+import android.content.Context
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import uk.gov.android.onelogin.R
+
+class AppUnavailableBodyTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var icon: SemanticsMatcher
+    private lateinit var header: SemanticsMatcher
+    private lateinit var content: SemanticsMatcher
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        icon = hasTestTag(ICON_TAG)
+        header = hasText(context.getString(R.string.app_appUnavailableTitle))
+        content = hasText(context.getString(R.string.app_appUnavailableBody))
+    }
+
+    @Test
+    fun verifyUI() {
+        // Given the AppUnavailableBody Composable
+        composeTestRule.setContent {
+            AppUnavailableBody()
+        }
+        // Then the UI elements are visible
+        composeTestRule.onNode(icon).assertIsDisplayed()
+        composeTestRule.onNode(header).assertIsDisplayed()
+        composeTestRule.onNode(content).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreenTest.kt
@@ -1,0 +1,36 @@
+package uk.gov.onelogin.feature.unavailable.ui
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.NoActivityResumedException
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Test
+import uk.gov.onelogin.TestCase
+
+@HiltAndroidTest
+class AppUnavailableScreenTest : TestCase() {
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun onHardwareBackButton() {
+        composeTestRule.setContent {
+            AppUnavailableScreen()
+        }
+        composeTestRule.waitForIdle()
+        try {
+            Espresso.pressBack()
+        } catch (_: NoActivityResumedException) {
+        }
+    }
+
+    @Test
+    fun previewTest() {
+        composeTestRule.setContent {
+            AppUnavailablePreview()
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreen.kt
@@ -48,7 +48,7 @@ fun AppUnavailableScreen() {
 
 @Composable
 internal fun AppUnavailableBody() {
-    // TODO update typography references when UI is updated
+    // Update typography references when UI is updated
     val color = colorScheme.contentColorFor(colorScheme.background)
     Box(
         modifier = Modifier

--- a/app/src/main/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/feature/unavailable/ui/AppUnavailableScreen.kt
@@ -1,0 +1,99 @@
+package uk.gov.onelogin.feature.unavailable.ui
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.colorScheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.rememberNavController
+import uk.gov.android.onelogin.R
+import uk.gov.android.ui.components.R as Res
+import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.smallPadding
+import uk.gov.android.ui.theme.spacingDouble
+import uk.gov.onelogin.core.meta.ExcludeFromJacocoGeneratedReport
+import uk.gov.onelogin.core.meta.ScreenPreview
+import uk.gov.onelogin.navigation.closeApp
+
+internal const val ICON_TAG = "icon.tag"
+private val iconSize = 100.dp
+private val iconPadding = 1.dp
+
+@Composable
+fun AppUnavailableScreen() {
+    val navController = rememberNavController()
+    GdsTheme { AppUnavailableBody() }
+    BackHandler { navController.closeApp() }
+}
+
+@Composable
+internal fun AppUnavailableBody() {
+    // TODO update typography references when UI is updated
+    val color = colorScheme.contentColorFor(colorScheme.background)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(smallPadding),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier.verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(spacingDouble, Alignment.Top),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                modifier = Modifier
+                    .padding(iconPadding)
+                    .size(iconSize)
+                    .testTag(ICON_TAG),
+                painter = painterResource(Res.drawable.ic_error),
+                contentDescription = null,
+                tint = color
+            )
+            Text(
+                color = color,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .semantics { heading() },
+                style = MaterialTheme.typography.headlineLarge, // `displaySmall`
+                text = stringResource(R.string.app_appUnavailableTitle),
+                textAlign = TextAlign.Center
+            )
+            Text(
+                color = color,
+                modifier = Modifier
+                    .fillMaxWidth(),
+                style = MaterialTheme.typography.bodyLarge, // `bodySmall`
+                text = stringResource(R.string.app_appUnavailableBody),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@ExcludeFromJacocoGeneratedReport
+@ScreenPreview
+@Composable
+internal fun AppUnavailablePreview() {
+    GdsTheme { AppUnavailableBody() }
+}

--- a/app/src/main/java/uk/gov/onelogin/ui/error/ErrorGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/ErrorGraphObject.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import uk.gov.onelogin.feature.unavailable.ui.AppUnavailableScreen
 import uk.gov.onelogin.ui.error.update.UpdateRequiredScreen
 
 object ErrorGraphObject {
@@ -53,6 +54,11 @@ object ErrorGraphObject {
                     context.finishAndRemoveTask()
                 }
                 UpdateRequiredScreen()
+            }
+            composable(
+                route = ErrorRoutes.Unavailable.getRoute()
+            ) {
+                AppUnavailableScreen()
             }
         }
     }

--- a/app/src/main/java/uk/gov/onelogin/ui/error/ErrorRoutes.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/ErrorRoutes.kt
@@ -8,6 +8,7 @@ sealed class ErrorRoutes(private val route: String) : NavRoute {
     data object Offline : ErrorRoutes("/error/offline")
     data object SignOut : ErrorRoutes("/error/signOut")
     data object UpdateRequired : ErrorRoutes("/error/updateRequired")
+    data object Unavailable : ErrorRoutes("/error/unavailable")
 
     override fun getRoute() = route
 }

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -47,6 +47,10 @@
     <string name="app_signInErrorBody">Gallwch geisio mewngofnodi eto. Os na fydd hyn yn gweithio, efallai y bydd angen i chi roi cynnig arall yn nes ymlaen.</string>
 
     <!-- Errors-->
+    <!-- App Unavailable -->
+    <string name="app_appUnavailableTitle">Mae\'n ddrwg gennym, nid yw\'r ap ar gael</string>
+    <string name="app_appUnavailableBody">Ni allwch ddefnyddio\'r ap GOV.UK One Login ar hyn o bryd.\n\nRhowch gynnig arall yn nes ymlaen.</string>
+
     <!-- Errors Generic-->
     <string name="app_somethingWentWrongErrorTitle">Aeth rhywbeth o\'i le</string>
     <string name="app_somethingWentWrongErrorBody">Rhowch gynnig arall yn nes ymlaen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,10 @@
     <string name="app_signInIconDescription" translatable="false">Gov Uk Icon</string>
 
     <!-- Errors -->
+    <!-- App Unavailable -->
+    <string name="app_appUnavailableTitle">Sorry, the app is unavailable</string>
+    <string name="app_appUnavailableBody">You cannot use the GOV.UK One Login app at the moment.\n\nTry again later.</string>
+
     <!-- Errors Generic -->
     <string name="app_somethingWentWrongErrorTitle">Something went wrong</string>
     <string name="app_somethingWentWrongErrorBody">Try again later.</string>


### PR DESCRIPTION
# [DCMAW-9823](https://govukverify.atlassian.net/browse/DCMAW-9823) App unavailable page

- UI for the App unavailable page only
- Content description matches the one used for the same icon elsewhere i.e. nothing

This PR deliberately does not have the acceptance criteria for showing the screen, just the UI and back button only.

## Evidence of the change

English
![DCMAW-9823-En](https://github.com/user-attachments/assets/d2d79120-5986-4b9d-8a95-0892c0bc94bc)
![DCMAW-9823-En-Dark](https://github.com/user-attachments/assets/5b48a661-7379-4954-a396-166d3ebd56b1)

Welsh
![DCMAW-9823-Cy](https://github.com/user-attachments/assets/4773e669-c556-481a-8067-419781514edb)
![DCMAW-9823-Cy-Dark](https://github.com/user-attachments/assets/282613ec-981a-486a-8c31-af4406757ce6)

Scenario 4: User taps hardware back button the ‘App unavailable’ page 
GIVEN I’m a user on the strategic app 
AND I'm on the ‘App unavailable’ page
WHEN I tap the hardware back button
THEN I exit the app

https://github.com/user-attachments/assets/d1f99e76-1e16-4361-b8de-fa10ac33a1da

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [x] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-onelogin-app
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing

[DCMAW-9823]: https://govukverify.atlassian.net/browse/DCMAW-9823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ