### PR TITLE
refactor: WelcomeScreenViewModel

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/core/utils/AndroidUriParserTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/core/utils/AndroidUriParserTest.kt
@@ -1,0 +1,15 @@
+package uk.gov.onelogin.core.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AndroidUriParserTest {
+    private val parser = AndroidUriParser()
+
+    @Test
+    fun checkParser() {
+        val result = parser.parse("www.google.com")
+
+        assertEquals("www.google.com", result.path)
+    }
+}

--- a/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/e2e/LoginTest.kt
@@ -258,7 +258,7 @@ class LoginTest : TestCase() {
             redirectUri = redirectUrl,
             scopes = listOf(LoginSessionConfiguration.Scope.OPENID),
             tokenEndpoint = tokenEndpoint,
-            persistentSessionId = persistentId
+            persistentSessionId = PERSISTENT_ID
         )
 
         verify(mockLoginSession).present(any(), eq(loginConfig))
@@ -440,7 +440,10 @@ class LoginTest : TestCase() {
     }
 
     private fun clickLogin() {
-        composeRule.waitForIdle()
+        composeRule.waitUntil(TIMEOUT) {
+            composeRule.onNodeWithText(resources.getString(R.string.app_signInButton))
+                .isDisplayed()
+        }
         composeRule.onNodeWithText(resources.getString(R.string.app_signInButton)).performClick()
     }
 
@@ -459,9 +462,9 @@ class LoginTest : TestCase() {
     private suspend fun setPersistentId() {
         secureStore.upsert(
             key = Keys.PERSISTENT_ID_KEY,
-            value = persistentId
+            value = PERSISTENT_ID
         )
-        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, persistentId).apply()
+        sharedPrefs.edit().putString(Keys.PERSISTENT_ID_KEY, PERSISTENT_ID).apply()
     }
 
     private fun deletePersistentId() {
@@ -471,7 +474,8 @@ class LoginTest : TestCase() {
     }
 
     companion object {
-        private const val persistentId = "cc893ece-b6bd-444d-9bb4-dec6f5778e50"
+        private const val TIMEOUT = 10000L
+        private const val PERSISTENT_ID = "cc893ece-b6bd-444d-9bb4-dec6f5778e50"
         private val tokenResponse = TokenResponse(
             tokenType = "test",
             accessToken = "test",

--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/splash/SplashScreenTest.kt
@@ -27,7 +27,9 @@ import uk.gov.onelogin.appinfo.service.domain.model.AppInfoServiceState
 import uk.gov.onelogin.appinfo.source.domain.source.AppInfoLocalSource
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.login.state.LocalAuthStatus
-import uk.gov.onelogin.login.usecase.HandleLogin
+import uk.gov.onelogin.login.usecase.HandleLocalLogin
+import uk.gov.onelogin.login.usecase.HandleLoginRedirect
+import uk.gov.onelogin.login.usecase.HandleRemoteLogin
 import uk.gov.onelogin.login.usecase.SaveTokens
 import uk.gov.onelogin.login.usecase.UseCaseModule
 import uk.gov.onelogin.login.usecase.VerifyIdToken
@@ -51,7 +53,13 @@ class SplashScreenTest : TestCase() {
     val verifyIdToken: VerifyIdToken = mock()
 
     @BindValue
-    val handleLogin: HandleLogin = mock()
+    val handleLocalLogin: HandleLocalLogin = mock()
+
+    @BindValue
+    val handleRemoteLogin: HandleRemoteLogin = mock()
+
+    @BindValue
+    val handleLoginRedirect: HandleLoginRedirect = mock()
 
     @BindValue
     val mockNavigator: Navigator = mock()
@@ -116,7 +124,7 @@ class SplashScreenTest : TestCase() {
         wheneverBlocking {
             analyticsRepo.isOptInPreferenceRequired()
         }.thenReturn(flow { emit(false) })
-        wheneverBlocking { handleLogin.invoke(any(), any()) }.thenAnswer {
+        wheneverBlocking { handleLocalLogin.invoke(any(), any()) }.thenAnswer {
             (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(LocalAuthStatus.UserCancelled)
         }
 
@@ -128,7 +136,7 @@ class SplashScreenTest : TestCase() {
             composeTestRule.onNode(unlockButton).isDisplayed()
         }
 
-        wheneverBlocking { handleLogin.invoke(any(), any()) }.thenAnswer {
+        wheneverBlocking { handleLocalLogin.invoke(any(), any()) }.thenAnswer {
             (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(LocalAuthStatus.ManualSignIn)
         }
 

--- a/app/src/main/java/uk/gov/onelogin/core/delete/Module.kt
+++ b/app/src/main/java/uk/gov/onelogin/core/delete/Module.kt
@@ -10,6 +10,7 @@ import uk.gov.onelogin.core.delete.domain.MultiCleaner
 import uk.gov.onelogin.login.biooptin.BiometricPreferenceHandler
 import uk.gov.onelogin.optin.domain.repository.OptInRepository
 import uk.gov.onelogin.tokens.usecases.RemoveAllSecureStoreData
+import uk.gov.onelogin.tokens.usecases.RemoveTokenExpiry
 
 @Module
 @InstallIn(ViewModelComponent::class)
@@ -18,9 +19,11 @@ internal object Module {
     fun provideCleaner(
         optInRepository: OptInRepository,
         biometricPreferenceHandler: BiometricPreferenceHandler,
-        secureStoreData: RemoveAllSecureStoreData
+        secureStoreData: RemoveAllSecureStoreData,
+        removeTokenExpiry: RemoveTokenExpiry
     ): Cleaner = MultiCleaner(
         Dispatchers.Default,
+        removeTokenExpiry,
         optInRepository,
         biometricPreferenceHandler,
         secureStoreData

--- a/app/src/main/java/uk/gov/onelogin/core/utils/UriParser.kt
+++ b/app/src/main/java/uk/gov/onelogin/core/utils/UriParser.kt
@@ -3,7 +3,7 @@ package uk.gov.onelogin.core.utils
 import android.net.Uri
 import javax.inject.Inject
 
-interface UriParser {
+fun interface UriParser {
     fun parse(uri: String): Uri
 }
 

--- a/app/src/main/java/uk/gov/onelogin/core/utils/UriParser.kt
+++ b/app/src/main/java/uk/gov/onelogin/core/utils/UriParser.kt
@@ -1,0 +1,13 @@
+package uk.gov.onelogin.core.utils
+
+import android.net.Uri
+import javax.inject.Inject
+
+interface UriParser {
+    fun parse(uri: String): Uri
+}
+
+class AndroidUriParser @Inject constructor() : UriParser {
+    override fun parse(uri: String) =
+        Uri.parse(uri)
+}

--- a/app/src/main/java/uk/gov/onelogin/core/utils/UtilsModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/core/utils/UtilsModule.kt
@@ -1,0 +1,13 @@
+package uk.gov.onelogin.core.utils
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+@Module
+@InstallIn(ViewModelComponent::class)
+interface UtilsModule {
+    @Binds
+    fun bindUriParser(parser: AndroidUriParser): UriParser
+}

--- a/app/src/main/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModel.kt
@@ -16,7 +16,7 @@ import uk.gov.onelogin.appinfo.service.domain.AppInfoService
 import uk.gov.onelogin.appinfo.service.domain.model.AppInfoServiceState
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.login.state.LocalAuthStatus
-import uk.gov.onelogin.login.usecase.HandleLogin
+import uk.gov.onelogin.login.usecase.HandleLocalLogin
 import uk.gov.onelogin.mainnav.MainNavRoutes
 import uk.gov.onelogin.navigation.NavRoute
 import uk.gov.onelogin.navigation.Navigator
@@ -26,7 +26,7 @@ import uk.gov.onelogin.ui.error.ErrorRoutes
 @HiltViewModel
 class SplashScreenViewModel @Inject constructor(
     private val navigator: Navigator,
-    private val handleLogin: HandleLogin,
+    private val handleLocalLogin: HandleLocalLogin,
     private val appInfoService: AppInfoService
 ) : ViewModel(), DefaultLifecycleObserver {
 
@@ -38,7 +38,7 @@ class SplashScreenViewModel @Inject constructor(
 
     fun login(fragmentActivity: FragmentActivity) {
         viewModelScope.launch {
-            handleLogin(
+            handleLocalLogin(
                 fragmentActivity,
                 callback = {
                     when (it) {

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLocalLogin.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLocalLogin.kt
@@ -12,20 +12,20 @@ import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiry
 import uk.gov.onelogin.tokens.usecases.IsAccessTokenExpired
 
-fun interface HandleLogin {
+fun interface HandleLocalLogin {
     suspend operator fun invoke(
         fragmentActivity: FragmentActivity,
         callback: (LocalAuthStatus) -> Unit
     )
 }
 
-class HandleLoginImpl @Inject constructor(
+class HandleLocalLoginImpl @Inject constructor(
     private val getTokenExpiry: GetTokenExpiry,
     private val tokenRepository: TokenRepository,
     private val isAccessTokenExpired: IsAccessTokenExpired,
     private val getFromTokenSecureStore: GetFromTokenSecureStore,
     private val bioPrefHandler: BiometricPreferenceHandler
-) : HandleLogin {
+) : HandleLocalLogin {
     override suspend fun invoke(
         fragmentActivity: FragmentActivity,
         callback: (LocalAuthStatus) -> Unit

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLoginRedirect.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLoginRedirect.kt
@@ -9,7 +9,7 @@ import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.onelogin.appcheck.AppIntegrity
 import uk.gov.onelogin.appcheck.AttestationResult
 
-interface HandleLoginRedirect {
+fun interface HandleLoginRedirect {
     suspend fun handle(
         intent: Intent,
         onFailure: (Throwable?) -> Unit,

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLoginRedirect.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleLoginRedirect.kt
@@ -1,0 +1,115 @@
+package uk.gov.onelogin.login.usecase
+
+import android.content.Intent
+import javax.inject.Inject
+import uk.gov.android.authentication.integrity.AppIntegrityParameters
+import uk.gov.android.authentication.integrity.pop.SignedPoP
+import uk.gov.android.authentication.login.LoginSession
+import uk.gov.android.authentication.login.TokenResponse
+import uk.gov.onelogin.appcheck.AppIntegrity
+import uk.gov.onelogin.appcheck.AttestationResult
+
+interface HandleLoginRedirect {
+    suspend fun handle(
+        intent: Intent,
+        onFailure: (Throwable?) -> Unit,
+        onSuccess: (TokenResponse) -> Unit
+    )
+}
+
+class HandleLoginRedirectImpl @Inject constructor(
+    private val appIntegrity: AppIntegrity,
+    private val loginSession: LoginSession
+) : HandleLoginRedirect {
+    override suspend fun handle(
+        intent: Intent,
+        onFailure: (Throwable?) -> Unit,
+        onSuccess: (TokenResponse) -> Unit
+    ) {
+        val savedAttestation = appIntegrity.retrieveSavedClientAttestation()
+        // Attempt to get a new attestation if the saved one is not available due to device or open secure store
+        // Very unlikely to occur
+        if (savedAttestation.isNullOrEmpty()) {
+            handleGetClientAttestation(
+                onSuccess = { attestation ->
+                    handleCreatePoP(
+                        attestation = attestation,
+                        onSuccess = { jwt ->
+                            loginSession.finalise(
+                                intent = intent,
+                                appIntegrity = AppIntegrityParameters(attestation, jwt)
+                            ) { tokens ->
+                                onSuccess(tokens)
+                            }
+                        },
+                        onFailure = onFailure
+                    )
+                },
+                onFailure = onFailure
+            )
+            // Attestation retrieved successfully, directly create PoP
+        } else {
+            handleCreatePoP(
+                attestation = savedAttestation,
+                onSuccess = { jwt ->
+                    loginSession.finalise(
+                        intent = intent,
+                        appIntegrity = AppIntegrityParameters(savedAttestation, jwt)
+                    ) { tokens ->
+                        onSuccess(tokens)
+                    }
+                },
+                onFailure = onFailure
+            )
+        }
+    }
+
+    private suspend fun handleGetClientAttestation(
+        onSuccess: (String) -> Unit,
+        onFailure: (Throwable?) -> Unit
+    ) {
+        when (val attestation = appIntegrity.getClientAttestation()) {
+            is AttestationResult.Failure ->
+                onFailure(Error(attestation.error))
+
+            is AttestationResult.NotRequired ->
+                onSuccess(
+                    attestation.savedAttestation ?: ""
+                )
+
+            is AttestationResult.Success ->
+                onSuccess(
+                    attestation.clientAttestation
+                )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun handleCreatePoP(
+        attestation: String,
+        onSuccess: (popJwt: String) -> Unit,
+        onFailure: (Throwable?) -> Unit
+    ) {
+        if (attestation.isNotEmpty()) {
+            when (val popResult = appIntegrity.getProofOfPossession()) {
+                is SignedPoP.Success ->
+                    try {
+                        onSuccess(popResult.popJwt)
+                    } catch (e: Throwable) { // handle both Error and Exception types.
+                        // Includes AuthenticationError
+                        onFailure(e)
+                    }
+
+                is SignedPoP.Failure ->
+                    onFailure(popResult.error)
+            }
+        } else {
+            try {
+                onSuccess("")
+            } catch (e: Throwable) { // handle both Error and Exception types.
+                // Includes AuthenticationError
+                onFailure(e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleRemoteLogin.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleRemoteLogin.kt
@@ -16,7 +16,7 @@ import uk.gov.onelogin.features.StsFeatureFlag
 import uk.gov.onelogin.tokens.usecases.GetPersistentId
 import uk.gov.onelogin.ui.LocaleUtils
 
-interface HandleRemoteLogin {
+fun interface HandleRemoteLogin {
     suspend fun login(
         launcher: ActivityResultLauncher<Intent>,
         onFailure: () -> Unit

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/HandleRemoteLogin.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/HandleRemoteLogin.kt
@@ -1,0 +1,109 @@
+package uk.gov.onelogin.login.usecase
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import uk.gov.android.authentication.login.LoginSession
+import uk.gov.android.authentication.login.LoginSessionConfiguration
+import uk.gov.android.features.FeatureFlags
+import uk.gov.android.onelogin.R
+import uk.gov.onelogin.appcheck.AppIntegrity
+import uk.gov.onelogin.appcheck.AttestationResult
+import uk.gov.onelogin.core.utils.UriParser
+import uk.gov.onelogin.features.StsFeatureFlag
+import uk.gov.onelogin.tokens.usecases.GetPersistentId
+import uk.gov.onelogin.ui.LocaleUtils
+
+interface HandleRemoteLogin {
+    suspend fun login(
+        launcher: ActivityResultLauncher<Intent>,
+        onFailure: () -> Unit
+    )
+}
+
+@Suppress("LongParameterList")
+class HandleRemoteLoginImpl @Inject constructor(
+    @ApplicationContext
+    private val context: Context,
+    private val featureFlags: FeatureFlags,
+    private val localeUtils: LocaleUtils,
+    private val loginSession: LoginSession,
+    private val getPersistentId: GetPersistentId,
+    private val appIntegrity: AppIntegrity,
+    private val uriParser: UriParser
+) : HandleRemoteLogin {
+    override suspend fun login(
+        launcher: ActivityResultLauncher<Intent>,
+        onFailure: () -> Unit
+    ) {
+        val persistentId = getPersistentId()?.takeIf { it.isNotEmpty() }
+        handleGetClientAttestation(
+            {
+                loginSession.present(
+                    launcher,
+                    configuration = createLoginConfiguration(persistentId)
+                )
+            },
+            onFailure
+        )
+    }
+
+    private suspend fun handleGetClientAttestation(
+        onSuccess: () -> Unit,
+        onFailure: () -> Unit
+    ) {
+        when (appIntegrity.getClientAttestation()) {
+            is AttestationResult.Failure -> onFailure()
+
+            else -> onSuccess()
+        }
+    }
+
+    private fun createLoginConfiguration(persistentId: String?): LoginSessionConfiguration {
+        val locale = localeUtils.getLocaleAsSessionConfig()
+        val authorizeEndpoint = uriParser.parse(
+            context.getString(
+                if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+                    R.string.stsUrl
+                } else {
+                    R.string.openIdConnectBaseUrl
+                },
+                context.getString(R.string.openIdConnectAuthorizeEndpoint)
+            )
+        )
+        val tokenEndpoint = uriParser.parse(
+            context.getString(
+                if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+                    R.string.stsUrl
+                } else {
+                    R.string.apiBaseUrl
+                },
+                context.getString(R.string.tokenExchangeEndpoint)
+            )
+        )
+        val redirectUri = uriParser.parse(
+            context.getString(
+                R.string.webBaseUrl,
+                context.getString(R.string.webRedirectEndpoint)
+            )
+        )
+        val clientId = if (featureFlags[StsFeatureFlag.STS_ENDPOINT]) {
+            context.getString(R.string.stsClientId)
+        } else {
+            context.getString(R.string.openIdConnectClientId)
+        }
+        val scopes = listOf(LoginSessionConfiguration.Scope.OPENID)
+
+        return LoginSessionConfiguration(
+            authorizeEndpoint = authorizeEndpoint,
+            clientId = clientId,
+            locale = locale,
+            redirectUri = redirectUri,
+            scopes = scopes,
+            tokenEndpoint = tokenEndpoint,
+            persistentSessionId = persistentId
+        )
+    }
+}

--- a/app/src/main/java/uk/gov/onelogin/login/usecase/UseCaseModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/usecase/UseCaseModule.kt
@@ -9,11 +9,17 @@ import dagger.hilt.android.components.ViewModelComponent
 @Module
 interface UseCaseModule {
     @Binds
-    fun bindHandleLogin(useCase: HandleLoginImpl): HandleLogin
+    fun bindHandleLogin(useCase: HandleLocalLoginImpl): HandleLocalLogin
 
     @Binds
     fun bindVerifyIdToken(usecase: VerifyIdTokenImpl): VerifyIdToken
 
     @Binds
     fun bindSaveTokens(saveTokens: SaveTokensImpl): SaveTokens
+
+    @Binds
+    fun bindHandleRemoteLogin(handleLogin: HandleRemoteLoginImpl): HandleRemoteLogin
+
+    @Binds
+    fun bindHandleLoginRedirect(handleRedirect: HandleLoginRedirectImpl): HandleLoginRedirect
 }

--- a/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/appcheck/AppIntegrityImplTest.kt
@@ -127,6 +127,8 @@ class AppIntegrityImplTest {
             whenever(appCheck.getAttestation())
                 .thenReturn(AttestationResponse.Success(SUCCESS, 0))
             val result = sut.getClientAttestation()
+
+            verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
             assertEquals(AttestationResult.Success(SUCCESS), result)
         }
 
@@ -144,6 +146,8 @@ class AppIntegrityImplTest {
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
         val result = sut.getClientAttestation()
+
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
         assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
@@ -160,6 +164,8 @@ class AppIntegrityImplTest {
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
         val result = sut.getClientAttestation()
+
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
         assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
@@ -181,6 +187,8 @@ class AppIntegrityImplTest {
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
         val result = sut.getClientAttestation()
+
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
         assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
@@ -201,6 +209,8 @@ class AppIntegrityImplTest {
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
         val result = sut.getClientAttestation()
+
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
         assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
@@ -222,6 +232,8 @@ class AppIntegrityImplTest {
         whenever(appCheck.getAttestation())
             .thenReturn(AttestationResponse.Success(SUCCESS, 0))
         val result = sut.getClientAttestation()
+
+        verify(saveToOpenSecureStore).save(CLIENT_ATTESTATION, SUCCESS)
         assertEquals(AttestationResult.Success(SUCCESS), result)
     }
 
@@ -232,6 +244,7 @@ class AppIntegrityImplTest {
             AttestationResponse.Failure(reason = FAILURE, error = Exception(FAILURE))
         )
         val result = sut.getClientAttestation()
+
         assertEquals(AttestationResult.Failure(FAILURE), result)
     }
 

--- a/app/src/test/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/ui/splash/SplashScreenViewModelTest.kt
@@ -23,7 +23,7 @@ import uk.gov.onelogin.extensions.CoroutinesTestExtension
 import uk.gov.onelogin.extensions.InstantExecutorExtension
 import uk.gov.onelogin.login.LoginRoutes
 import uk.gov.onelogin.login.state.LocalAuthStatus
-import uk.gov.onelogin.login.usecase.HandleLogin
+import uk.gov.onelogin.login.usecase.HandleLocalLogin
 import uk.gov.onelogin.mainnav.MainNavRoutes
 import uk.gov.onelogin.navigation.Navigator
 import uk.gov.onelogin.signOut.SignOutRoutes
@@ -32,7 +32,7 @@ import uk.gov.onelogin.ui.error.ErrorRoutes
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class SplashScreenViewModelTest {
-    private val mockHandleLogin: HandleLogin = mock()
+    private val mockHandleLocalLogin: HandleLocalLogin = mock()
     private val mockNavigator: Navigator = mock()
     private val mockLifeCycleOwner: LifecycleOwner = mock()
     private val mockActivity: FragmentActivity = mock()
@@ -42,13 +42,13 @@ class SplashScreenViewModelTest {
 
     private val viewModel = SplashScreenViewModel(
         mockNavigator,
-        mockHandleLogin,
+        mockHandleLocalLogin,
         mockAppInfoService
     )
 
     @Test
     fun loginFailsWithSecureStoreError() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.SecureStoreError
@@ -62,7 +62,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun loginFailsWithBioCheckFailed() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.BioCheckFailed
@@ -75,7 +75,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun loginSuccess() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.Success(mapOf("key" to "token"))
@@ -89,7 +89,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun loginRequiresRefresh() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.ManualSignIn
@@ -103,7 +103,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun loginRequiresReAuth() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.ReAuthSignIn
@@ -117,7 +117,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun loginReturnsUserCancelled() = runTest {
-        whenever(mockHandleLogin.invoke(any(), any()))
+        whenever(mockHandleLocalLogin.invoke(any(), any()))
             .thenAnswer {
                 (it.arguments[1] as (LocalAuthStatus) -> Unit).invoke(
                     LocalAuthStatus.UserCancelled
@@ -142,7 +142,7 @@ class SplashScreenViewModelTest {
         viewModel.login(mockActivity)
 
         // THEN do NOT login (as the app will be going to background)
-        verify(mockHandleLogin, times(1)).invoke(any(), any())
+        verify(mockHandleLocalLogin, times(1)).invoke(any(), any())
     }
 
     @Test

--- a/app/src/test/java/uk/gov/onelogin/login/usecase/HandleLocalLoginTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/usecase/HandleLocalLoginTest.kt
@@ -21,7 +21,7 @@ import uk.gov.onelogin.tokens.usecases.GetFromTokenSecureStore
 import uk.gov.onelogin.tokens.usecases.GetTokenExpiry
 import uk.gov.onelogin.tokens.usecases.IsAccessTokenExpired
 
-class HandleLoginTest {
+class HandleLocalLoginTest {
     private val mockActivity: FragmentActivity = mock()
     private val mockGetTokenExpiry: GetTokenExpiry = mock()
     private val mockTokenRepository: TokenRepository = mock()
@@ -29,7 +29,7 @@ class HandleLoginTest {
     private val mockBioPrefHandler: BiometricPreferenceHandler = mock()
     private val mockIsAccessTokenExpired: IsAccessTokenExpired = mock()
 
-    private val useCase = HandleLoginImpl(
+    private val useCase = HandleLocalLoginImpl(
         mockGetTokenExpiry,
         mockTokenRepository,
         mockIsAccessTokenExpired,

--- a/app/src/test/java/uk/gov/onelogin/login/usecase/HandleLoginRedirectTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/usecase/HandleLoginRedirectTest.kt
@@ -1,0 +1,172 @@
+package uk.gov.onelogin.login.usecase
+
+import android.content.Intent
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.integrity.AppIntegrityParameters
+import uk.gov.android.authentication.integrity.pop.SignedPoP
+import uk.gov.android.authentication.login.LoginSession
+import uk.gov.android.authentication.login.TokenResponse
+import uk.gov.onelogin.appcheck.AppIntegrity
+import uk.gov.onelogin.appcheck.AttestationResult
+
+@Suppress("MaxLineLength")
+@OptIn(ExperimentalCoroutinesApi::class)
+class HandleLoginRedirectTest {
+
+    private val mockAppIntegrity: AppIntegrity = mock()
+    private val mockLoginSession: LoginSession = mock()
+    private val mockIntent: Intent = mock()
+
+    private val testJwt = "testJwt"
+    private val testAttestation = "testAttestation"
+    private val testAccessToken = "testAccessToken"
+    private var testIdToken: String = "testIdToken"
+    private val tokenResponse = TokenResponse(
+        "testType",
+        testAccessToken,
+        1L,
+        testIdToken,
+        "testRefreshToken"
+    )
+
+    private val handleLoginRedirect = HandleLoginRedirectImpl(mockAppIntegrity, mockLoginSession)
+
+    @Test
+    fun `handle() should call onSuccess with tokens when attestation and PoP are successful`() =
+        runTest {
+            whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn(testAttestation)
+            whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(SignedPoP.Success(testJwt))
+            whenever(mockLoginSession.finalise(any(), any(), any())).thenAnswer {
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+            }
+
+            // When
+            handleLoginRedirect.handle(
+                mockIntent,
+                { },
+                {
+                    assertEquals(tokenResponse, it)
+                }
+            )
+        }
+
+    @Test
+    fun `handle() should call onFailure when getProofOfPossession returns Failure`() = runTest {
+        whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn(testAttestation)
+        whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(
+            SignedPoP.Failure(
+                "test",
+                Error("error")
+            )
+        )
+
+        // When
+        handleLoginRedirect.handle(
+            mockIntent,
+            {
+                assertEquals("error", it?.message)
+            },
+            { }
+        )
+
+        verifyNoInteractions(mockLoginSession)
+    }
+
+    @Test
+    fun `onSuccess, savedAttestation is null and attestation and PoP are successful`() =
+        runTest {
+            whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn(null)
+            whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+                AttestationResult.Success(testAttestation)
+            )
+            whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(SignedPoP.Success(testJwt))
+            whenever(mockLoginSession.finalise(any(), any(), any())).thenAnswer {
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                val appIntegrityParameters = it.arguments[1] as AppIntegrityParameters
+                assertEquals("", appIntegrityParameters.attestation)
+            }
+
+            // When
+            handleLoginRedirect.handle(
+                mockIntent,
+                { },
+                {
+                    assertEquals(tokenResponse, it)
+                }
+            )
+        }
+
+    @Test
+    fun `onSuccess, savedAttestation is empty and attestation and PoP are successful`() =
+        runTest {
+            whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn("")
+            whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+                AttestationResult.Success(testAttestation)
+            )
+            whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(SignedPoP.Success(testJwt))
+            whenever(mockLoginSession.finalise(any(), any(), any())).thenAnswer {
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                val appIntegrityParameters = it.arguments[1] as AppIntegrityParameters
+                assertEquals("", appIntegrityParameters.attestation)
+            }
+
+            // When
+            handleLoginRedirect.handle(
+                mockIntent,
+                { },
+                {
+                    assertEquals(tokenResponse, it)
+                }
+            )
+        }
+
+    @Test
+    fun `onFailure, savedAttestation is null and getClientAttestation returns Failure`() =
+        runTest {
+            whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn(null)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.Failure("error"))
+            whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(SignedPoP.Success(testJwt))
+
+            // When
+            handleLoginRedirect.handle(
+                mockIntent,
+                {
+                    assertEquals("error", it?.message)
+                },
+                { }
+            )
+
+            verifyNoInteractions(mockLoginSession)
+        }
+
+    @Test
+    fun `onSuccess, when savedAttestation is null and getClientAttestation returns NotRequired`() =
+        runTest {
+            whenever(mockAppIntegrity.retrieveSavedClientAttestation()).thenReturn(null)
+            whenever(mockAppIntegrity.getClientAttestation())
+                .thenReturn(AttestationResult.NotRequired(testAttestation))
+            whenever(mockAppIntegrity.getProofOfPossession()).thenReturn(SignedPoP.Success(testJwt))
+            whenever(mockLoginSession.finalise(any(), any(), any())).thenAnswer {
+                (it.arguments[2] as (token: TokenResponse) -> Unit).invoke(tokenResponse)
+                val appIntegrityParameters = it.arguments[1] as AppIntegrityParameters
+                assertEquals(testAttestation, appIntegrityParameters.attestation)
+            }
+
+            // When
+            handleLoginRedirect.handle(
+                mockIntent,
+                { },
+                {
+                    assertEquals(tokenResponse, it)
+                }
+            )
+        }
+}

--- a/app/src/test/java/uk/gov/onelogin/login/usecase/HandleRemoteLoginTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/login/usecase/HandleRemoteLoginTest.kt
@@ -1,0 +1,162 @@
+package uk.gov.onelogin.login.usecase
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.android.authentication.login.LoginSession
+import uk.gov.android.authentication.login.LoginSessionConfiguration
+import uk.gov.android.features.FeatureFlags
+import uk.gov.onelogin.appcheck.AppIntegrity
+import uk.gov.onelogin.appcheck.AttestationResult
+import uk.gov.onelogin.core.utils.UriParser
+import uk.gov.onelogin.tokens.usecases.GetPersistentId
+import uk.gov.onelogin.ui.LocaleUtils
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HandleRemoteLoginTest {
+    private val mockContext: Context = mock()
+    private val mockFeatureFlags: FeatureFlags = mock()
+    private val mockGetPersistentId: GetPersistentId = mock()
+    private val mockLocaleUtils: LocaleUtils = mock()
+    private val mockLoginSession: LoginSession = mock()
+    private val mockAppIntegrity: AppIntegrity = mock()
+    private val mockUriParser: UriParser = mock()
+    private val mockLauncher: ActivityResultLauncher<Intent> = mock()
+    private val mockUri: Uri = mock()
+    private val testAttestation = "testAttestation"
+    private val testPersistentId = "12345"
+
+    private lateinit var handleRemoteLogin: HandleRemoteLogin
+
+    @BeforeEach
+    fun setUp() {
+        handleRemoteLogin = HandleRemoteLoginImpl(
+            mockContext,
+            mockFeatureFlags,
+            mockLocaleUtils,
+            mockLoginSession,
+            mockGetPersistentId,
+            mockAppIntegrity,
+            mockUriParser
+        )
+
+        whenever(mockContext.getString(any())).thenReturn("")
+        whenever(mockContext.getString(any(), any<String>())).thenReturn("")
+        whenever(mockLocaleUtils.getLocaleAsSessionConfig()).thenReturn(
+            LoginSessionConfiguration.Locale.EN
+        )
+        whenever(mockUriParser.parse(any())).thenReturn(mockUri)
+    }
+
+    @Test
+    fun `login() - success with persistentId`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn(testPersistentId)
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.Success(testAttestation)
+        )
+
+        handleRemoteLogin.login(mockLauncher) {}
+
+        argumentCaptor<LoginSessionConfiguration> {
+            verify(mockLoginSession).present(eq(mockLauncher), capture())
+            val capturedConfiguration = firstValue
+            assertEquals(testPersistentId, capturedConfiguration.persistentSessionId)
+            assertEquals(LoginSessionConfiguration.Locale.EN, capturedConfiguration.locale)
+        }
+    }
+
+    @Test
+    fun `login() - success without persistentId`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn(null)
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.Success(testAttestation)
+        )
+
+        handleRemoteLogin.login(mockLauncher) {}
+
+        argumentCaptor<LoginSessionConfiguration> {
+            verify(mockLoginSession).present(eq(mockLauncher), capture())
+            val capturedConfiguration = firstValue
+            assertEquals(null, capturedConfiguration.persistentSessionId)
+            assertEquals(LoginSessionConfiguration.Locale.EN, capturedConfiguration.locale)
+        }
+    }
+
+    @Test
+    fun `login() - success with empty persistentId`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn("")
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.Success(testAttestation)
+        )
+
+        handleRemoteLogin.login(mockLauncher) {}
+
+        argumentCaptor<LoginSessionConfiguration> {
+            verify(mockLoginSession).present(eq(mockLauncher), capture())
+            val capturedConfiguration = firstValue
+            assertEquals(null, capturedConfiguration.persistentSessionId)
+            assertEquals(LoginSessionConfiguration.Locale.EN, capturedConfiguration.locale)
+        }
+    }
+
+    @Test
+    fun `login() - handles AttestationResult Failure`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn(testPersistentId)
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.Failure("error")
+        )
+        var checkFailed = false
+
+        handleRemoteLogin.login(mockLauncher) {
+            checkFailed = true
+        }
+
+        assert(checkFailed)
+    }
+
+    @Test
+    fun `login() - handles AttestationResult NotRequired with savedAttestation`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn(testPersistentId)
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.NotRequired(testAttestation)
+        )
+
+        handleRemoteLogin.login(mockLauncher) {}
+
+        argumentCaptor<LoginSessionConfiguration> {
+            verify(mockLoginSession).present(eq(mockLauncher), capture())
+            val capturedConfiguration = firstValue
+            assertEquals(testPersistentId, capturedConfiguration.persistentSessionId)
+            assertEquals(LoginSessionConfiguration.Locale.EN, capturedConfiguration.locale)
+        }
+    }
+
+    @Test
+    fun `login() - handles AttestationResult NotRequired without savedAttestation`() = runTest {
+        whenever(mockGetPersistentId.invoke()).thenReturn(testPersistentId)
+        whenever(mockAppIntegrity.getClientAttestation()).thenReturn(
+            AttestationResult.NotRequired(null)
+        )
+
+        handleRemoteLogin.login(mockLauncher) {}
+
+        argumentCaptor<LoginSessionConfiguration> {
+            verify(mockLoginSession).present(eq(mockLauncher), capture())
+            val capturedConfiguration = firstValue
+            assertEquals(testPersistentId, capturedConfiguration.persistentSessionId)
+            assertEquals(LoginSessionConfiguration.Locale.EN, capturedConfiguration.locale)
+        }
+    }
+}


### PR DESCRIPTION
The main idea is to break up the complexity of the `WelcomeScreenViewModel`. This refactor hasn't reduced the constructor parameters tooo much unfortunately however the general complexity of the view model has been reduced.

- Remove `LoginSession` calls from `WelcomeScreenViewiodel`
- HandLeRemoteLogin.kt handles logic to do with starting the signing process via the *LoginSession •present()• and getting the client attestation
- HandleLoginRedirect.kt handles the response back from the login redirect, sets up the necessary bits for app integrity (attestation and PoP) to attach to the /token call to complete login
- Uri parser created for ease of testing
