### PR TITLE
docs: Adding documentation for app integrity setup

### DIFF
--- a/docs/developer-setup/app-integrity.md
+++ b/docs/developer-setup/app-integrity.md
@@ -1,0 +1,10 @@
+### App Integrity
+
+As part of the login process [Firebase App Check](https://firebase.google.com/docs/app-check/android/play-integrity-provider)
+is used in conjunction with some backend functions to ensure we are dealing with a
+legitimate version of the app.
+
+To build the app it requires that a `debugAppCheckToken` is provided. This should be set in
+your local `~/.gradle/gradle.properties` file. This is a debug secret and will need to be
+acquired via the relevant internal channels. However the app should build if there is an empty 
+or 'dummy' string in the `gradle.properties` file.

--- a/docs/developer-setup/git-hooks.md
+++ b/docs/developer-setup/git-hooks.md
@@ -25,3 +25,8 @@ available.
 [Project's Git Hooks]: /.githooks
 
 [Git Hook Framework]: https://git-scm.com/docs/githooks
+
+### Note
+
+Generally we don't run the `pre-push` hook because it runs all the Android Tests which
+can take a while


### PR DESCRIPTION
Just a little update to explain the situation with the Firebase debug secret