### PR TITLE
feat: Integrate CriOrchestrator in the one-login app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,7 +185,8 @@ dependencies {
         projects.features,
         libs.runtime.livedata,
         platform(libs.firebase.bom),
-        libs.bundles.firebase
+        libs.bundles.firebase,
+        libs.cri.orchestrator
     ).forEach(::implementation)
 
     implementation(libs.wallet.sdk) {

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenKtTest.kt
@@ -1,7 +1,5 @@
 package uk.gov.onelogin.ui.home
 
-import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.onNodeWithText
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
 import uk.gov.onelogin.TestCase
@@ -13,24 +11,6 @@ class HomeScreenKtTest : TestCase() {
     fun initialisesHomeScreen() {
         composeTestRule.setupComposeTestRule { _ ->
             HomeScreen()
-        }
-    }
-
-    @Test
-    fun testCriOrchestratorInit() {
-        composeTestRule.setupComposeTestRule { _ ->
-            HomeScreen()
-        }
-        composeTestRule.apply {
-            onNodeWithText(
-                "CRI Orchestrator Init:",
-                substring = true
-            ).assertIsDisplayed()
-
-            onNodeWithText(
-                "uk.gov.onelogin.criorchestrator.sdk",
-                substring = true
-            ).assertIsDisplayed()
         }
     }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenKtTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/ui/home/HomeScreenKtTest.kt
@@ -1,5 +1,7 @@
 package uk.gov.onelogin.ui.home
 
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
 import dagger.hilt.android.testing.HiltAndroidTest
 import org.junit.Test
 import uk.gov.onelogin.TestCase
@@ -11,6 +13,24 @@ class HomeScreenKtTest : TestCase() {
     fun initialisesHomeScreen() {
         composeTestRule.setupComposeTestRule { _ ->
             HomeScreen()
+        }
+    }
+
+    @Test
+    fun testCriOrchestratorInit() {
+        composeTestRule.setupComposeTestRule { _ ->
+            HomeScreen()
+        }
+        composeTestRule.apply {
+            onNodeWithText(
+                "CRI Orchestrator Init:",
+                substring = true
+            ).assertIsDisplayed()
+
+            onNodeWithText(
+                "uk.gov.onelogin.criorchestrator.sdk",
+                substring = true
+            ).assertIsDisplayed()
         }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/login/ui/splash/SplashScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/ui/splash/SplashScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.login.ui.splash
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -20,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -54,7 +54,7 @@ import uk.gov.onelogin.optin.ui.OptInRequirementViewModel
 fun SplashScreen(
     viewModel: SplashScreenViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current as FragmentActivity
+    val context = LocalActivity.current as FragmentActivity
     val lifecycleOwner = LocalLifecycleOwner.current
     val optInRequirementViewModel: OptInRequirementViewModel = hiltViewModel()
     val loading = viewModel.loading.collectAsState()

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignOutScreen.kt
@@ -1,9 +1,9 @@
 package uk.gov.onelogin.signOut.ui
 
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -24,7 +24,7 @@ fun SignOutScreen(
     val loading by viewModel.loadingState.collectAsState()
     val analytics: SignOutAnalyticsViewModel = hiltViewModel()
     // Needed for deleteWalletData
-    val fragmentActivity = LocalContext.current as FragmentActivity
+    val fragmentActivity = LocalActivity.current as FragmentActivity
 
     if (loading) {
         LoadingScreen {

--- a/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/signOut/ui/SignedOutInfoScreen.kt
@@ -2,6 +2,7 @@ package uk.gov.onelogin.signOut.ui
 
 import android.app.Activity
 import android.content.Intent
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -11,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -35,7 +35,7 @@ fun SignedOutInfoScreen(
 ) {
     val loading by loginViewModel.loading.collectAsState()
     val analytics: SignedOutInfoAnalyticsViewModel = hiltViewModel()
-    val activity = LocalContext.current as FragmentActivity
+    val activity = LocalActivity.current as FragmentActivity
     val launcher = rememberLauncherForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) { result: ActivityResult ->

--- a/app/src/main/java/uk/gov/onelogin/ui/error/ErrorGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/error/ErrorGraphObject.kt
@@ -2,7 +2,7 @@ package uk.gov.onelogin.ui.error
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.compose.ui.platform.LocalContext
+import androidx.activity.compose.LocalActivity
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -27,7 +27,7 @@ object ErrorGraphObject {
             composable(
                 route = ErrorRoutes.SignOut.getRoute()
             ) {
-                val context = LocalContext.current as FragmentActivity
+                val context = LocalActivity.current as FragmentActivity
                 SignOutErrorScreen {
                     context.finishAndRemoveTask()
                 }
@@ -48,7 +48,7 @@ object ErrorGraphObject {
             composable(
                 route = ErrorRoutes.UpdateRequired.getRoute()
             ) {
-                val context = LocalContext.current as Activity
+                val context = LocalActivity.current as Activity
                 BackHandler(enabled = true) {
                     // Close/ terminate the app
                     context.finishAndRemoveTask()

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.ui.home
 
+import android.util.Log
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -26,17 +27,13 @@ fun HomeScreen(
 ) {
     val tokens = viewModel.getTokens()
     val email = viewModel.email
-    val httpClient = viewModel.getHttpClient()
+    val httpClient = viewModel.httpClient
     TitledPage(
         parameters = TitledPageParameters(
             R.string.app_homeTitle
         ) {
             val criOrchestratorComponent = rememberCriOrchestrator(httpClient)
-            Text(
-                text = "CRI Orchestrator Init: $criOrchestratorComponent",
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(16.dp)
-            )
+            Log.d("CriIOrchestratorInstance", "$criOrchestratorComponent")
             EmailHeader(email)
             Text(
                 text = "Access Token",

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreen.kt
@@ -14,6 +14,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.R
 import uk.gov.android.ui.pages.TitledPage
 import uk.gov.android.ui.pages.TitledPageParameters
+import uk.gov.onelogin.criorchestrator.sdk.publicapi.rememberCriOrchestrator
 import uk.gov.onelogin.developer.DeveloperTools
 import uk.gov.onelogin.ui.components.EmailHeader
 
@@ -25,10 +26,17 @@ fun HomeScreen(
 ) {
     val tokens = viewModel.getTokens()
     val email = viewModel.email
+    val httpClient = viewModel.getHttpClient()
     TitledPage(
         parameters = TitledPageParameters(
             R.string.app_homeTitle
         ) {
+            val criOrchestratorComponent = rememberCriOrchestrator(httpClient)
+            Text(
+                text = "CRI Orchestrator Init: $criOrchestratorComponent",
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(16.dp)
+            )
             EmailHeader(email)
             Text(
                 text = "Access Token",

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
@@ -12,7 +12,7 @@ import uk.gov.onelogin.tokens.usecases.GetEmail
 @HiltViewModel
 @Suppress("LongParameterList")
 class HomeScreenViewModel @Inject constructor(
-    private val httpClient: GenericHttpClient,
+    val httpClient: GenericHttpClient,
     private val navigator: Navigator,
     private val tokenRepository: TokenRepository,
     getEmail: GetEmail
@@ -25,9 +25,5 @@ class HomeScreenViewModel @Inject constructor(
 
     fun openDevPanel() {
         navigator.openDeveloperPanel()
-    }
-
-    fun getHttpClient(): GenericHttpClient {
-        return httpClient
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/ui/home/HomeScreenViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import uk.gov.android.authentication.login.TokenResponse
+import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.onelogin.navigation.Navigator
 import uk.gov.onelogin.repositiories.TokenRepository
 import uk.gov.onelogin.tokens.usecases.GetEmail
@@ -11,6 +12,7 @@ import uk.gov.onelogin.tokens.usecases.GetEmail
 @HiltViewModel
 @Suppress("LongParameterList")
 class HomeScreenViewModel @Inject constructor(
+    private val httpClient: GenericHttpClient,
     private val navigator: Navigator,
     private val tokenRepository: TokenRepository,
     getEmail: GetEmail
@@ -23,5 +25,9 @@ class HomeScreenViewModel @Inject constructor(
 
     fun openDevPanel() {
         navigator.openDeveloperPanel()
+    }
+
+    fun getHttpClient(): GenericHttpClient {
+        return httpClient
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
@@ -2,7 +2,6 @@ package uk.gov.onelogin.ui.home
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
@@ -51,12 +50,5 @@ class HomeScreenViewModelTest {
         viewModel.openDevPanel()
 
         verify(mockNavigator).openDeveloperPanel()
-    }
-
-    @Test
-    fun httpClientProvided() {
-        val result = viewModel.getHttpClient()
-
-        assertNotNull(result)
     }
 }

--- a/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/ui/home/HomeScreenViewModelTest.kt
@@ -2,11 +2,13 @@ package uk.gov.onelogin.ui.home
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.onelogin.extensions.CoroutinesTestExtension
 import uk.gov.onelogin.extensions.InstantExecutorExtension
 import uk.gov.onelogin.navigation.Navigator
@@ -19,9 +21,11 @@ class HomeScreenViewModelTest {
     private val mockNavigator: Navigator = mock()
     private val tokenRepository: TokenRepository = mock()
     private val getEmail: GetEmail = mock()
+    private val httpClient: GenericHttpClient = mock()
 
     private val viewModel by lazy {
         HomeScreenViewModel(
+            httpClient,
             mockNavigator,
             tokenRepository,
             getEmail
@@ -47,5 +51,12 @@ class HomeScreenViewModelTest {
         viewModel.openDevPanel()
 
         verify(mockNavigator).openDeveloperPanel()
+    }
+
+    @Test
+    fun httpClientProvided() {
+        val result = viewModel.getHttpClient()
+
+        assertNotNull(result)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,10 +82,10 @@ plugins {
 }
 
 setProperty("appId", "uk.gov.onelogin")
-setProperty("compileSdkVersion", 34)
+setProperty("compileSdkVersion", 35)
 setProperty("configDir", "${rootProject.rootDir}/config")
 setProperty("minSdkVersion", 29)
-setProperty("targetSdkVersion", 34)
+setProperty("targetSdkVersion", 35)
 
 val jacocoVersion: String by rootProject.extra(
     libs.versions.jacoco.get(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,9 +45,9 @@ govuk-ui = "5.7.5"
 govuk-logging = "0.11.0"
 compose-runtime = "1.7.6"
 wallet = "1.34.0"
+cri-ochestrator = "0.7.2"
 
 [libraries]
-wallet-sdk = { module = "uk.gov.android.wallet:wallet_sdk", version.ref = "wallet" }
 runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose-runtime" }
 jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
 test-core-ktx = { group = "androidx.test", name = "core-ktx", version = "1.6.1" }
@@ -96,6 +96,9 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref = "classgraph" }
 
 # GDS
+wallet-sdk = { module = "uk.gov.android.wallet:wallet_sdk", version.ref = "wallet" }
+cri-orchestrator = { module = "uk.gov.onelogin.criorchestrator.sdk:sdk", version.ref = "cri-ochestrator"}
+
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ govuk-ui = "5.7.5"
 govuk-logging = "0.11.0"
 compose-runtime = "1.7.6"
 wallet = "1.34.0"
-cri-ochestrator = "0.7.2"
+cri-orchestrator = "0.7.2"
 
 [libraries]
 runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "compose-runtime" }
@@ -97,7 +97,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 
 # GDS
 wallet-sdk = { module = "uk.gov.android.wallet:wallet_sdk", version.ref = "wallet" }
-cri-orchestrator = { module = "uk.gov.onelogin.criorchestrator.sdk:sdk", version.ref = "cri-ochestrator"}
+cri-orchestrator = { module = "uk.gov.onelogin.criorchestrator.sdk:sdk", version.ref = "cri-orchestrator" }
 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }


### PR DESCRIPTION
**Ticket Link:** 
[DCMAW-10992](https://govukverify.atlassian.net/browse/DCMAW-10992)

**Description Of Changes:**
- update `compileSdkVersion` and `targetSdkVersion` to 35 to enable use of `CriOrchestratorSdk` which uses `androidx.activity` version 1.10.0
- update all instances of using `LocalContext.current` as `FragmentActivity` to `LocalActivity.current`
- add temporary functionality to display the instance of `CriOrchestratorSdk` 

**Evidence:**
Video showing regression, after `CriOrchestrator` integration, the app works as expected (as the instance of the `CriOrchestrator` is initialised on the `HomeScreen`)

https://github.com/user-attachments/assets/62795a3a-35e0-4a0e-89bc-3134c9e513d1


Logs showing instance initialised:
```
2025-01-29 13:37:34.519  8260-8260  CriIOrches...orInstance uk.gov.onelogin.build                D  uk.gov.onelogin.criorchestrator.sdk.internal.DaggerMergedBaseCriOrchestratorComponent$MergedBaseCriOrchestratorComponentImpl@40415a9
```

**Definition Of Done Checklist:**

- [ ] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [x] Relevant integration and end-to-end tests are written
- [x] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [ ] Sonar coverage gates met 
- [ ] If feature flagged, Feature is enabled in staging and manually tested to ensure integration

Resolves: DCMAW-10992

[DCMAW-10992]: https://govukverify.atlassian.net/browse/DCMAW-10992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ