### PR TITLE
fix: Amend AndroidManifest to remove `uk.gov.android.securestore.TestActivity`

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,10 @@
                 <data android:path="/redirect"/>
             </intent-filter>
         </activity>
+        <activity
+            android:name="uk.gov.android.securestore.TestActivity"
+            tools:node="remove" >
+        </activity>
 
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
         <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />


### PR DESCRIPTION
**Ticket Link:** 
[DCMAW-10252](https://govukverify.atlassian.net/browse/DCMAW-10252)

**Description Of Changes:** 
- amend AndroidManifest to remove `uk.gov.android.securestore.TestActivity` which allows for only one launcher when running the app

**Evidence:**

https://github.com/user-attachments/assets/60c148d9-1c12-48d2-aee7-2bac343a5cca


**Definition Of Done Checklist:**

- [ ] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [ ] Relevant integration and end-to-end tests are written
- [ ] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [ ] Sonar coverage gates met 
- [ ] If feature flagged, Feature is enabled in staging and manually tested to ensure integration

Resolves: DCMAW-10252

[DCMAW-10252]: https://govukverify.atlassian.net/browse/DCMAW-10252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ