### PR TITLE
fix: Fix minify error for publish to PlayStore

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,3 +22,4 @@
 
 -dontwarn kotlinx.parcelize.Parcelize
 -dontwarn javax.servlet.ServletContainerInitializer
+-keep class com.squareup.anvil.annotations.**

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application>
         <activity
             android:name="uk.gov.onelogin.HiltTestActivity"
@@ -11,6 +11,10 @@
             android:name="uk.gov.onelogin.TestActivityForResult"
             android:exported="false"
             android:permission="">
+        </activity>
+        <activity
+            android:name="uk.gov.android.securestore.TestActivity"
+            tools:node="remove" >
         </activity>
     </application>
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,10 +46,6 @@
                 <data android:path="/redirect"/>
             </intent-filter>
         </activity>
-        <activity
-            android:name="uk.gov.android.securestore.TestActivity"
-            tools:node="remove" >
-        </activity>
 
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />
         <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="false" />


### PR DESCRIPTION
- add keep class for Annotations used in CriOrchestrator to be kept
- move the `uk.gov.android.securestore.TestActivity` remove node to debug as it would only show in debug - keep production `Manifest` clean

Resolves: DCMAW-10693