### PR TITLE
fix: Amend pro-guard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,4 +25,4 @@
 -dontwarn com.squareup.anvil.annotations.ContributesBinding
 -dontwarn com.squareup.anvil.annotations.ContributesTo
 -dontwarn com.squareup.anvil.annotations.internal.InternalMergedTypeMarker
--keep class com.squareup.anvil.**
+-keep class com.squareup.anvil.annotations.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,4 +22,4 @@
 
 -dontwarn kotlinx.parcelize.Parcelize
 -dontwarn javax.servlet.ServletContainerInitializer
--keep class com.squareup.anvil.annotations.**
+-dontwarn com.squareup.anvil.**

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,4 +22,7 @@
 
 -dontwarn kotlinx.parcelize.Parcelize
 -dontwarn javax.servlet.ServletContainerInitializer
--dontwarn com.squareup.anvil.**
+-dontwarn com.squareup.anvil.annotations.ContributesBinding
+-dontwarn com.squareup.anvil.annotations.ContributesTo
+-dontwarn com.squareup.anvil.annotations.internal.InternalMergedTypeMarker
+-keep class com.squareup.anvil.**


### PR DESCRIPTION
- used the wrong pro-guard rule - missing classes should use `dontwarn`, while missing dependencies, `keep` is used for runtime classes

Resolves: DCMAW-10693