### PR TITLE
refactor: Update AnalyticsViewModel test

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/login/ui/biooptin/BioOptInAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/login/ui/biooptin/BioOptInAnalyticsViewModelTest.kt
@@ -13,8 +13,9 @@ import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel2
 import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
-import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.logging.api.v3dot1.model.ViewEvent
+import uk.gov.onelogin.TrackEventTestCase
+import uk.gov.onelogin.executeTrackEventTestCase
 
 class BioOptInAnalyticsViewModelTest {
     private lateinit var name: String
@@ -54,26 +55,24 @@ class BioOptInAnalyticsViewModelTest {
     }
 
     @Test
-    fun trackBiometricsButton() {
-        val event = TrackEvent.Button(
-            text = biometricsBtn,
-            params = requiredParameters
-        )
+    fun trackButtons() {
+        listOf(
+            TrackEventTestCase.Button(
+                trackFunction = {
+                    viewModel.trackBiometricsButton()
+                },
+                text = biometricsBtn
+            ),
+            TrackEventTestCase.Button(
+                trackFunction = {
+                    viewModel.trackPasscodeButton()
+                },
+                text = passcodeBtn
+            )
+        ).forEach {
+            val result = executeTrackEventTestCase(it, requiredParameters)
 
-        viewModel.trackBiometricsButton()
-
-        verify(logger).logEventV3Dot1(event)
-    }
-
-    @Test
-    fun trackPasscodeButton() {
-        val event = TrackEvent.Button(
-            text = passcodeBtn,
-            params = requiredParameters
-        )
-
-        viewModel.trackPasscodeButton()
-
-        verify(logger).logEventV3Dot1(event)
+            verify(logger).logEventV3Dot1(result)
+        }
     }
 }

--- a/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutAnalyticsViewModelTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/signOut/ui/SignOutAnalyticsViewModelTest.kt
@@ -14,7 +14,8 @@ import uk.gov.logging.api.analytics.parameters.data.TaxonomyLevel3
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
-import uk.gov.logging.api.v3dot1.model.ViewEvent
+import uk.gov.onelogin.TrackEventTestCase
+import uk.gov.onelogin.executeTrackEventTestCase
 
 class SignOutAnalyticsViewModelTest {
     private lateinit var buttonText: String
@@ -54,56 +55,48 @@ class SignOutAnalyticsViewModelTest {
     }
 
     @Test
-    fun trackSignOutLogsTrackCloseIcon() {
-        // Given a TrackEvent.Link
-        val event = TrackEvent.Icon(
-            text = "back",
-            params = requiredParameters
-        )
-        // When tracking re-auth
-        viewModel.trackCloseIcon()
-        // Then log a TrackEvent to the AnalyticsLogger
-        verify(logger).logEventV3Dot1(event)
+    fun trackIcons() {
+        listOf(
+            TrackEventTestCase.Icon(
+                trackFunction = {
+                    viewModel.trackCloseIcon()
+                },
+                text = "back"
+            ),
+            TrackEventTestCase.Icon(
+                trackFunction = {
+                    viewModel.trackBackPressed()
+                },
+                text = "back - system"
+            )
+        ).forEach {
+            val result = executeTrackEventTestCase(it, requiredParameters)
+
+            verify(logger).logEventV3Dot1(result)
+        }
     }
 
     @Test
-    fun trackSignOutLogsTrackBackPressed() {
-        // Given a TrackEvent.Link
-        val event = TrackEvent.Icon(
-            text = "back - system",
-            params = requiredParameters
-        )
-        // When tracking re-auth
-        viewModel.trackBackPressed()
-        // Then log a TrackEvent to the AnalyticsLogger
-        verify(logger).logEventV3Dot1(event)
-    }
+    fun trackScreens() {
+        listOf(
+            TrackEventTestCase.Screen(
+                trackFunction = {
+                    viewModel.trackSignOutView(SignOutUIState.Wallet)
+                },
+                name = name,
+                id = walletId
+            ),
+            TrackEventTestCase.Screen(
+                trackFunction = {
+                    viewModel.trackSignOutView(SignOutUIState.NoWallet)
+                },
+                name = name,
+                id = noWalletId
+            )
+        ).forEach {
+            val result = executeTrackEventTestCase(it, requiredParameters)
 
-    @Test
-    fun trackSignOutWalletViewLogsViewEventScreen() {
-        // Given a ViewEvent.Screen
-        val event = ViewEvent.Screen(
-            name = name,
-            id = walletId,
-            params = requiredParameters
-        )
-        // When tracking the signed out info screen view
-        viewModel.trackSignOutView(SignOutUIState.Wallet)
-        // Then log a ScreenView to the AnalyticsLogger
-        verify(logger).logEventV3Dot1(event)
-    }
-
-    @Test
-    fun trackSignOutViewLogsViewEventScreen() {
-        // Given a ViewEvent.Screen
-        val event = ViewEvent.Screen(
-            name = name,
-            id = noWalletId,
-            params = requiredParameters
-        )
-        // When tracking the signed out info screen view
-        viewModel.trackSignOutView(SignOutUIState.NoWallet)
-        // Then log a ScreenView to the AnalyticsLogger
-        verify(logger).logEventV3Dot1(event)
+            verify(logger).logEventV3Dot1(result)
+        }
     }
 }


### PR DESCRIPTION
## Description of changes

Very simple change to move any existing `AnalyticsViewModel` test which  check multiple of the same `TrackEvent` types to use the recently introduced `TrackEventTestCase`