### PR TITLE
feat: Changing layout and copy of AuthErrorScreen

### DIFF
--- a/core/src/main/res/values-cy/strings.xml
+++ b/core/src/main/res/values-cy/strings.xml
@@ -98,17 +98,22 @@
     <string name="app_privacyNoticeLink">Darllenwch fwy am hyn yn hysbysiad preifatrwydd GOV.UK One Login</string>
     <string name="app_shareAnalyticsButton">Rhannu dadansoddeg</string>
     <string name="app_doNotShareAnalytics">Osgoi am y tro</string>
+
+    <!--  Update Required  -->
     <string name="app_updateApp_Title">Mae angen i chi ddiweddaru eich ap</string>
     <string name="app_updateAppBody1">Rydych yn defnyddio hen fersiwn o\'r ap GOV.UK One Login.</string>
     <string name="app_updateAppBody2">Diweddarwch eich ap i barhau</string>
     <string name="app_updateAppButton">Diweddaru Ap GOV.UK One Login</string>
+
+    <!--  Re-Auth Error  -->
     <string name="app_dataDeletedErrorTitle">Mae rhywbeth wedi mynd o\'i le</string>
-    <string name="app_dataDeletedErrorBody1">Rydym wedi dileu\'r wybodaeth yn eich ap GOV.UK One Login oherwydd nid oeddem yn gallu cadarnhau eich manylion mewngofnodi.</string>
-    <string name="app_dataDeletedErrorBody2">Mae hyn yn golygu:</string>
-    <string name="app_dataDeletedErrorBullet1">mae unrhyw ddogfennau a arbedwyd yn eich GOV.UK Wallet wedi cael eu dileu</string>
-    <string name="app_dataDeletedErrorBullet2">os oeddech chi\'n defnyddio biometreg neu pin neu batrwm eich ffôn i ddatgloi\'r ap, mae hyn wedi\'i ddiffodd</string>
-    <string name="app_dataDeletedErrorBullet3">mae\'r ap wedi rhoi\'r gorau i rannu dadansoddeg am sut rydych yn ei ddefnyddio</string>
-    <string name="app_dataDeletedErrorBody3">Er mwyn parhau i ddefnyddio\'r ap, bydd angen i chi fewngofnodi. Yna byddwch yn gallu ychwanegu eich dogfennau at eich GOV.UK Wallet a gosod eich dewisiadau eto.</string>
+    <string name="app_dataDeletedButton">Mewngofnodi</string>
+    <string name="app_dataDeletedBody1_no_wallet">Ni allem gadarnhau eich manylion mewngofnodi.</string>
+    <string name="app_dataDeletedBody2_no_wallet">Er mwyn cadw\'ch gwybodaeth yn ddiogel, mae eich dewis o ddefnyddio biometreg i ddatgloi\'r ap wedi\'i ailosod.</string>
+    <string name="app_dataDeletedBody3_no_wallet">Mae angen i chi fewngofnodi a gosod eich dewisiadau eto i barhau i ddefnyddio\'r ap.</string>
+    <string name="app_dataDeletedBody1">Ni allem gadarnhau eich manylion mewngofnodi.</string>
+    <string name="app_dataDeletedBody2">Er mwyn cadw\'ch gwybodaeth yn ddiogel, mae unrhyw ddogfennau yn eich GOV.UK  Wallet wedi\'u dileu ac mae eich dewisiadau ap wedi\'u hailosod.</string>
+    <string name="app_dataDeletedBody3">Mae angen i chi fewngofnodi eto a gosod eich dewisiadau eto i barhau i ddefnyddio\'r ap. Yna byddwch yn gallu ychwanegu dogfennau at eich GOV.UK  Wallet.</string>
 
     <!-- Url  -->
     <string name="privacy_notice_url">https://signin.account.gov.uk/privacy-notice?lng=cy</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -137,13 +137,14 @@
     
     <!-- Re-Auth Error -->
     <string name="app_dataDeletedErrorTitle">Something went wrong</string>
-    <string name="app_dataDeletedErrorBody1">We’ve deleted the information in your GOV.UK One Login app because we could not confirm your sign in details.</string>
-    <string name="app_dataDeletedErrorBody2">This means:</string>
-    <string name="app_dataDeletedErrorBullet1">any documents saved in your GOV.UK Wallet have been removed</string>
-    <string name="app_dataDeletedErrorBullet2">if you were using biometrics or your phone’s pin or pattern to unlock the app, this has been switched off</string>
-    <string name="app_dataDeletedErrorBullet3">the app has stopped sharing analytics about how you use it</string>
-    <string name="app_dataDeletedErrorBody3">To keep using the app, you’ll need to sign in. You’ll then be able to add your documents to your GOV.UK Wallet and set your preferences again.</string>
     <string name="app_dataDeletedError_ContentDescription" translatable="false">Data deleted error (re-auth) icon content description</string>
+    <string name="app_dataDeletedButton">Sign in</string>
+    <string name="app_dataDeletedBody1_no_wallet">We could not confirm your sign in details.</string>
+    <string name="app_dataDeletedBody2_no_wallet">To keep your information secure, your preference for using biometrics to unlock the app has been reset.</string>
+    <string name="app_dataDeletedBody3_no_wallet">You need to sign in and set your preferences again to continue using the app.</string>
+    <string name="app_dataDeletedBody1">We could not confirm your sign in details.</string>
+    <string name="app_dataDeletedBody2">To keep your information secure, any documents in your GOV.UK Wallet have been removed and your app preferences have been reset.</string>
+    <string name="app_dataDeletedBody3">You need to sign in again and set your preferences again to continue using the app. You’ll then be able to add documents to you GOV.UK Wallet.</string>
 
     <!-- Analytics Values   -->
     <string name="system_backButton" translatable="false">back - system</string>

--- a/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreenTest.kt
+++ b/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreenTest.kt
@@ -4,54 +4,93 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
-import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import uk.gov.android.featureflags.FeatureFlags
+import uk.gov.android.featureflags.InMemoryFeatureFlags
 import uk.gov.android.onelogin.core.R
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.features.TestCase
+import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 
 class AuthErrorScreenTest : TestCase() {
     private lateinit var viewModel: AuthErrorViewModel
     private val navigator: Navigator = mock()
-    private val title = hasText(resources.getString(R.string.app_dataDeletedErrorTitle))
-    private val intro = hasText(resources.getString(R.string.app_dataDeletedErrorBody1))
-    private val content = hasText(resources.getString(R.string.app_dataDeletedErrorBody2))
-    private val bulletItem1 = hasText(resources.getString(R.string.app_dataDeletedErrorBullet1))
-    private val bulletItem2 = hasText(resources.getString(R.string.app_dataDeletedErrorBullet2))
-    private val bulletItem3 = hasText(resources.getString(R.string.app_dataDeletedErrorBullet3))
-    private val instruction = hasText(resources.getString(R.string.app_dataDeletedErrorBody3))
-    private val primary = hasText(resources.getString(R.string.app_SignInWithGovUKOneLoginButton))
+    private lateinit var featureFlags: FeatureFlags
 
-    @Before
-    fun setup() {
-        viewModel = AuthErrorViewModel(navigator)
+    private val title = hasText(resources.getString(R.string.app_dataDeletedErrorTitle))
+    private val body1 = hasText(resources.getString(R.string.app_dataDeletedBody1))
+    private val body2 = hasText(resources.getString(R.string.app_dataDeletedBody2))
+    private val body3 = hasText(resources.getString(R.string.app_dataDeletedBody3))
+    private val body1NoWallet = hasText(
+        resources.getString(R.string.app_dataDeletedBody1_no_wallet)
+    )
+    private val body2NoWallet = hasText(
+        resources.getString(R.string.app_dataDeletedBody2_no_wallet)
+    )
+    private val body3NoWallet = hasText(
+        resources.getString(R.string.app_dataDeletedBody3_no_wallet)
+    )
+    private val primary = hasText(resources.getString(R.string.app_dataDeletedButton))
+
+    @Test
+    fun reAuthErrorScreenWithWallet() {
+        featureFlags = InMemoryFeatureFlags(
+            setOf(WalletFeatureFlag.ENABLED)
+        )
+        viewModel = AuthErrorViewModel(navigator, featureFlags)
         composeTestRule.setContent {
             AuthErrorScreen(viewModel)
         }
-    }
 
-    @Test
-    fun reAuthErrorScreen() {
         composeTestRule.apply {
             onNodeWithContentDescription(
                 context.getString(R.string.app_dataDeletedError_ContentDescription)
             ).assertIsDisplayed()
 
             onNode(title).assertIsDisplayed()
-            onNode(intro).assertIsDisplayed()
-            onNode(content).assertIsDisplayed()
-            onNode(bulletItem1).assertIsDisplayed()
-            onNode(bulletItem2).assertIsDisplayed()
-            onNode(bulletItem3).assertIsDisplayed()
-            onNode(instruction).assertIsDisplayed()
+            onNode(body1).assertIsDisplayed()
+            onNode(body2).assertIsDisplayed()
+            onNode(body3).assertIsDisplayed()
+            onNode(primary).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun reAuthErrorScreenWithoutWallet() {
+        featureFlags = InMemoryFeatureFlags(
+            setOf()
+        )
+        viewModel = AuthErrorViewModel(navigator, featureFlags)
+        composeTestRule.setContent {
+            AuthErrorScreen(viewModel)
+        }
+
+        composeTestRule.apply {
+            onNodeWithContentDescription(
+                context.getString(R.string.app_dataDeletedError_ContentDescription)
+            ).assertIsDisplayed()
+
+            onNode(title).assertIsDisplayed()
+            onNode(body1NoWallet).assertIsDisplayed()
+            onNode(body2NoWallet).assertIsDisplayed()
+            onNode(body3NoWallet).assertIsDisplayed()
+            onNode(primary).assertIsDisplayed()
         }
     }
 
     @Test
     fun onPrimary() {
+        featureFlags = InMemoryFeatureFlags(
+            setOf()
+        )
+        viewModel = AuthErrorViewModel(navigator, featureFlags)
+        composeTestRule.setContent {
+            AuthErrorScreen(viewModel)
+        }
+
         composeTestRule.onNode(primary)
             .performClick()
 

--- a/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreenTest.kt
+++ b/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreenTest.kt
@@ -96,4 +96,18 @@ class AuthErrorScreenTest : TestCase() {
 
         verify(navigator).navigate(LoginRoutes.Start, true)
     }
+
+    @Test
+    fun noWalletPreview() {
+        composeTestRule.setContent {
+            AuthErrorScreenNoWalletPreview()
+        }
+    }
+
+    @Test
+    fun preview() {
+        composeTestRule.setContent {
+            AuthErrorScreenPreview()
+        }
+    }
 }

--- a/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
+++ b/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
@@ -26,7 +26,6 @@ class GenericErrorScreenTest : TestCase() {
         analyticsLogger = mock()
         viewModel = GenericErrorAnalyticsViewModel(context, analyticsLogger)
         primaryClicked = false
-
     }
 
     @Test

--- a/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
+++ b/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
@@ -8,7 +8,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import uk.gov.android.onelogin.core.R
-import uk.gov.android.wallet.core.errors.GenericErrorScreenPreview
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.features.TestCase
 
@@ -61,7 +60,7 @@ class GenericErrorScreenTest : TestCase() {
     @Test
     fun preview() {
         composeTestRule.setContent {
-            GenericErrorScreenPreview()
+            GenericErrorPreview()
         }
     }
 }

--- a/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
+++ b/features/src/androidTest/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreenTest.kt
@@ -8,6 +8,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import uk.gov.android.onelogin.core.R
+import uk.gov.android.wallet.core.errors.GenericErrorScreenPreview
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.onelogin.features.TestCase
 
@@ -25,16 +26,18 @@ class GenericErrorScreenTest : TestCase() {
         analyticsLogger = mock()
         viewModel = GenericErrorAnalyticsViewModel(context, analyticsLogger)
         primaryClicked = false
+
+    }
+
+    @Test
+    fun genericErrorScreen() {
         composeTestRule.setContent {
             GenericErrorScreen(
                 analyticsViewModel = viewModel,
                 onClick = { primaryClicked = true }
             )
         }
-    }
 
-    @Test
-    fun genericErrorScreen() {
         composeTestRule.onNode(errorTitle).assertIsDisplayed()
         composeTestRule.onNode(errorBody).assertIsDisplayed()
         composeTestRule.onNode(primaryButton).apply {
@@ -46,6 +49,20 @@ class GenericErrorScreenTest : TestCase() {
 
     @Test
     fun onBackClicked() {
+        composeTestRule.setContent {
+            GenericErrorScreen(
+                analyticsViewModel = viewModel,
+                onClick = { primaryClicked = true }
+            )
+        }
+
         Espresso.pressBack()
+    }
+
+    @Test
+    fun preview() {
+        composeTestRule.setContent {
+            GenericErrorScreenPreview()
+        }
     }
 }

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorScreen.kt
@@ -1,190 +1,100 @@
 package uk.gov.onelogin.features.error.ui.auth
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.hilt.navigation.compose.hiltViewModel
 import uk.gov.android.onelogin.core.R
-import uk.gov.android.ui.components.R as UiR
 import uk.gov.android.ui.components.content.GdsContentText
-import uk.gov.android.ui.components.images.icon.IconParameters
-import uk.gov.android.ui.components.m3.BulletListParameters
-import uk.gov.android.ui.components.m3.GdsBulletList
-import uk.gov.android.ui.components.m3.Heading
-import uk.gov.android.ui.components.m3.HeadingSize
-import uk.gov.android.ui.components.m3.buttons.ButtonParameters
-import uk.gov.android.ui.components.m3.buttons.GdsButton
-import uk.gov.android.ui.components.m3.content.ContentParameters
-import uk.gov.android.ui.components.m3.content.GdsContent
-import uk.gov.android.ui.components.m3.images.icon.GdsIcon
+import uk.gov.android.ui.pages.LandingPage
+import uk.gov.android.ui.pages.LandingPageParameters
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.smallPadding
-import uk.gov.android.wallet.core.ui.theme.buttonHeight
-import uk.gov.onelogin.features.error.ui.auth.ErrorInformation.Companion.bulletPointIndentation
-import uk.gov.onelogin.features.error.ui.auth.ErrorInformation.Companion.bulletPointTextPadding
-import uk.gov.onelogin.features.error.ui.auth.ErrorInformation.Companion.listContentPadding
+import uk.gov.onelogin.core.ui.meta.ExcludeFromJacocoGeneratedReport
+import uk.gov.onelogin.core.ui.meta.ScreenPreview
 
 @Composable
 fun AuthErrorScreen(viewModel: AuthErrorViewModel = hiltViewModel()) {
     GdsTheme {
-        ConstraintLayout(
-            modifier = Modifier
-                .padding(horizontal = smallPadding)
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-        ) {
-            val (content, button) = createRefs()
-            Content(
-                parameters = ErrorInformation(
-                    title = R.string.app_dataDeletedErrorTitle,
-                    intro = R.string.app_dataDeletedErrorBody1,
-                    content = R.string.app_dataDeletedErrorBody2,
-                    bulletList = listOf(
-                        R.string.app_dataDeletedErrorBullet1,
-                        R.string.app_dataDeletedErrorBullet2,
-                        R.string.app_dataDeletedErrorBullet3
-                    ),
-                    instruction = R.string.app_dataDeletedErrorBody3
+        AuthErrorBody(viewModel.walletEnabled) {
+            viewModel.navigateToSignIn()
+        }
+    }
+}
+
+@Composable
+private fun AuthErrorBody(
+    walletEnabled: Boolean,
+    goToSignIn: () -> Unit = {}
+) {
+    val title = R.string.app_dataDeletedErrorTitle
+    val buttonText = R.string.app_dataDeletedButton
+    val contentDescription = R.string.app_dataDeletedError_ContentDescription
+    val bodyContent = if (walletEnabled) {
+        AuthScreenBodyContent(
+            body1 = R.string.app_dataDeletedBody1,
+            body2 = R.string.app_dataDeletedBody2,
+            body3 = R.string.app_dataDeletedBody3
+        )
+    } else {
+        AuthScreenBodyContent(
+            body1 = R.string.app_dataDeletedBody1_no_wallet,
+            body2 = R.string.app_dataDeletedBody2_no_wallet,
+            body3 = R.string.app_dataDeletedBody3_no_wallet
+        )
+    }
+    LandingPage(
+        landingPageParameters = LandingPageParameters(
+            topIcon = uk.gov.android.ui.components.R.drawable.ic_error,
+            iconColor = MaterialTheme.colorScheme.onBackground,
+            contentDescription = contentDescription,
+            title = title,
+            titleBottomPadding = smallPadding,
+            content = listOf(
+                GdsContentText.GdsContentTextString(
+                    text = intArrayOf(
+                        bodyContent.body1
+                    )
                 ),
-                modifier = Modifier
-                    .constrainAs(content) {
-                        top.linkTo(parent.top)
-                        bottom.linkTo(button.top)
-                        start.linkTo(parent.start)
-                        end.linkTo(parent.end)
-                    }
-            )
-            GdsButton(
-                buttonParameters = ButtonParameters(
-                    buttonType = uk.gov.android.ui.components.m3.buttons.ButtonType.PRIMARY(),
-                    onClick = { viewModel.navigateToSignIn() },
-                    text = stringResource(R.string.app_SignInWithGovUKOneLoginButton),
-                    modifier = Modifier
-                        .padding(bottom = smallPadding)
-                        .fillMaxWidth()
-                        .height(buttonHeight)
-                        .constrainAs(button) {
-                            bottom.linkTo(parent.bottom)
-                        }
+                GdsContentText.GdsContentTextString(
+                    text = intArrayOf(
+                        bodyContent.body2
+                    )
+                ),
+                GdsContentText.GdsContentTextString(
+                    text = intArrayOf(
+                        bodyContent.body3
+                    )
                 )
-            )
-        }
+            ),
+            contentInternalPadding = PaddingValues(bottom = smallPadding),
+            primaryButtonText = buttonText,
+            onPrimary = goToSignIn
+        )
+    )
+}
+
+internal data class AuthScreenBodyContent(
+    @StringRes val body1: Int,
+    @StringRes val body2: Int,
+    @StringRes val body3: Int
+)
+
+@ExcludeFromJacocoGeneratedReport
+@ScreenPreview
+@Composable
+internal fun AuthErrorScreenPreview() {
+    GdsTheme {
+        AuthErrorBody(true)
     }
 }
 
+@ExcludeFromJacocoGeneratedReport
+@ScreenPreview
 @Composable
-private fun Content(
-    parameters: ErrorInformation,
-    modifier: Modifier
-) {
-    val iconContentDescription =
-        stringResource(
-            id = R.string.app_dataDeletedError_ContentDescription
-        )
-    parameters.apply {
-        Column(
-            verticalArrangement = Arrangement.SpaceAround,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = modifier
-        ) {
-            GdsIcon(
-                parameters = IconParameters(
-                    image = UiR.drawable.ic_error,
-                    backGroundColor = MaterialTheme.colorScheme.background,
-                    foreGroundColor = MaterialTheme.colorScheme.onBackground,
-                    modifier = Modifier
-                        .padding(bottom = smallPadding)
-                        .semantics { contentDescription = iconContentDescription }
-                )
-            )
-            Introduction()
-            ContentList()
-            GdsContent(
-                contentParameters = ContentParameters(
-                    resource = listOf(
-                        GdsContentText.GdsContentTextString(
-                            intArrayOf(instruction)
-                        )
-                    ),
-                    textAlign = TextAlign.Center,
-                    textPadding = PaddingValues(top = smallPadding)
-                )
-            )
-        }
-    }
-}
-
-@Composable
-private fun ErrorInformation.ContentList() {
-    GdsContent(
-        contentParameters =
-        ContentParameters(
-            resource = listOf(
-                GdsContentText.GdsContentTextString(
-                    intArrayOf(content)
-                )
-            ),
-            textAlign = TextAlign.Start,
-            internalColumnModifier = Modifier.padding(bottom = listContentPadding)
-        )
-    )
-    GdsBulletList(
-        bulletListParameters = BulletListParameters(
-            indent = bulletPointIndentation,
-            textModifier = Modifier.padding(start = bulletPointTextPadding),
-            contentText = GdsContentText.GdsContentTextString(
-                text = bulletList.toIntArray()
-            )
-        )
-    )
-}
-
-@Composable
-private fun ErrorInformation.Introduction() {
-    Heading(
-        text = title,
-        size = HeadingSize.DisplaySmall(),
-        textAlign = TextAlign.Center,
-        padding = PaddingValues(bottom = smallPadding)
-    ).generate()
-    GdsContent(
-        contentParameters = ContentParameters(
-            resource = listOf(
-                GdsContentText.GdsContentTextString(
-                    intArrayOf(intro)
-                )
-            ),
-            textAlign = TextAlign.Center
-        )
-    )
-}
-
-data class ErrorInformation(
-    val title: Int,
-    val intro: Int,
-    val content: Int,
-    val bulletList: List<Int>,
-    val instruction: Int
-) {
-    companion object {
-        val listContentPadding = 12.dp
-        val bulletPointIndentation = 10.dp
-        val bulletPointTextPadding = 20.dp
+internal fun AuthErrorScreenNoWalletPreview() {
+    GdsTheme {
+        AuthErrorBody(false)
     }
 }

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorViewModel.kt
@@ -3,13 +3,18 @@ package uk.gov.onelogin.features.error.ui.auth
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import uk.gov.android.featureflags.FeatureFlags
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
+import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 
 @HiltViewModel
 class AuthErrorViewModel @Inject constructor(
-    private val navigator: Navigator
+    private val navigator: Navigator,
+    featureFlags: FeatureFlags
 ) : ViewModel() {
+    val walletEnabled = featureFlags[WalletFeatureFlag.ENABLED]
+
     fun navigateToSignIn() {
         navigator.navigate(LoginRoutes.Start, true)
     }

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/generic/GenericErrorScreen.kt
@@ -30,43 +30,52 @@ fun GenericErrorScreen(
             onClick()
         }
         LaunchedEffect(Unit) { analyticsViewModel.trackScreen() }
-        ErrorPage(
-            parameters = ErrorPageParameters(
-                primaryButtonParameters = ButtonParameters(
-                    buttonType = ButtonType.PRIMARY(),
-                    onClick = {
-                        analyticsViewModel.trackButton()
-                        onClick()
-                    },
-                    text = R.string.app_closeButton
-                ),
-                informationParameters = InformationParameters(
-                    contentParameters = ContentParameters(
-                        resource =
-                        listOf(
-                            GdsContentText.GdsContentTextString(
-                                subTitle = R.string.app_somethingWentWrongErrorTitle,
-                                text =
-                                intArrayOf(
-                                    R.string.app_somethingWentWrongErrorBody
-                                )
+        GenericErrorBody {
+            analyticsViewModel.trackButton()
+            onClick()
+        }
+    }
+}
+
+@Composable
+private fun GenericErrorBody(
+    primaryOnClick: () -> Unit = {}
+) {
+    ErrorPage(
+        parameters = ErrorPageParameters(
+            primaryButtonParameters = ButtonParameters(
+                buttonType = ButtonType.PRIMARY(),
+                onClick = primaryOnClick,
+                text = R.string.app_closeButton
+            ),
+            informationParameters = InformationParameters(
+                contentParameters = ContentParameters(
+                    resource =
+                    listOf(
+                        GdsContentText.GdsContentTextString(
+                            subTitle = R.string.app_somethingWentWrongErrorTitle,
+                            text =
+                            intArrayOf(
+                                R.string.app_somethingWentWrongErrorBody
                             )
-                        ),
-                        headingSize = HeadingSize.H1()
+                        )
                     ),
-                    iconParameters = IconParameters(
-                        foreGroundColor = Color.Unspecified,
-                        image = uk.gov.android.ui.components.R.drawable.ic_error
-                    )
+                    headingSize = HeadingSize.H1()
+                ),
+                iconParameters = IconParameters(
+                    foreGroundColor = Color.Unspecified,
+                    image = uk.gov.android.ui.components.R.drawable.ic_error
                 )
             )
         )
-    }
+    )
 }
 
 @ExcludeFromJacocoGeneratedReport
 @ScreenPreview
 @Composable
 internal fun GenericErrorPreview() {
-    GenericErrorScreen()
+    GdsTheme {
+        GenericErrorBody()
+    }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/error/ui/auth/AuthErrorViewModelTest.kt
@@ -1,21 +1,57 @@
 package uk.gov.onelogin.features.error.ui.auth
 
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import uk.gov.android.featureflags.FeatureFlags
+import uk.gov.android.featureflags.InMemoryFeatureFlags
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
+import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 
 class AuthErrorViewModelTest {
+    private lateinit var featureFlags: FeatureFlags
     private val mockNavigator: Navigator = mock()
-    private val sut = AuthErrorViewModel(mockNavigator)
 
     @Test
     fun `navigate to sign in`() =
         runTest {
+            featureFlags = InMemoryFeatureFlags(
+                setOf()
+            )
+            val sut = AuthErrorViewModel(mockNavigator, featureFlags)
+
             sut.navigateToSignIn()
 
             verify(mockNavigator).navigate(LoginRoutes.Start, popUpToInclusive = true)
+        }
+
+    @Test
+    fun `wallet enabled`() =
+        runTest {
+            featureFlags = InMemoryFeatureFlags(
+                setOf(WalletFeatureFlag.ENABLED)
+            )
+            val sut = AuthErrorViewModel(mockNavigator, featureFlags)
+
+            val result = sut.walletEnabled
+
+            assertTrue(result)
+        }
+
+    @Test
+    fun `wallet disabled`() =
+        runTest {
+            featureFlags = InMemoryFeatureFlags(
+                setOf()
+            )
+            val sut = AuthErrorViewModel(mockNavigator, featureFlags)
+
+            val result = sut.walletEnabled
+
+            assertFalse(result)
         }
 }


### PR DESCRIPTION
## [DCMAW-10097](https://govukverify.atlassian.net/browse/DCMAW-10097) and [DCMAW-11101](https://govukverify.atlassian.net/browse/DCMAW-11101) 

### Description of Changes
The `AuthErrorScreen` has been changed from an ErrorScreen template to a LandingPage template. This is mostly because the LandingPage uses M3 theme and is a little more inline with our current approach for UI. Having said that, it is still not perfect, but in the interests of time, using the template seems the best solution.

### Evidence
With wallet:

https://github.com/user-attachments/assets/625b760e-8d0b-4318-a1ce-c0cc0bc17fbd


Without Wallet:

https://github.com/user-attachments/assets/23ac055f-2bb8-4dc2-bd6e-4dd6025dd9a5



[DCMAW-10097]: https://govukverify.atlassian.net/browse/DCMAW-10097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DCMAW-11101]: https://govukverify.atlassian.net/browse/DCMAW-11101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ