### PR TITLE
feat: Update back button behaviour for login and sign out screens

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/navigation/graphs/LoginGraphObjectTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/navigation/graphs/LoginGraphObjectTest.kt
@@ -70,10 +70,9 @@ class LoginGraphObjectTest : TestCase() {
             resources.getString(R.string.app_enableBiometricsTitle)
         ).assertIsDisplayed()
         composeTestRule.back()
-        composeTestRule.onNodeWithText(
-            resources.getString(R.string.app_enableBiometricsTitle)
-        ).assertIsDisplayed()
-        composeTestRule.back()
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            assert(activity.isFinishing)
+        }
     }
 
     @FlakyTest
@@ -88,7 +87,7 @@ class LoginGraphObjectTest : TestCase() {
         ).assertIsDisplayed()
         composeTestRule.back()
         composeTestRule.onNodeWithText(
-            resources.getString(R.string.app_analyticsPermissionBody)
+            resources.getString(R.string.app_signInButton)
         ).assertIsDisplayed()
     }
 

--- a/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.navigation.graphs
 import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.ui.platform.LocalContext
-import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -31,7 +30,7 @@ object ErrorGraphObject {
             composable(
                 route = ErrorRoutes.SignOut.getRoute()
             ) {
-                val context = LocalContext.current as FragmentActivity
+                val context = LocalContext.current as Activity
                 SignOutErrorScreen {
                     context.finishAndRemoveTask()
                 }

--- a/app/src/main/java/uk/gov/onelogin/navigation/graphs/LoginGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/graphs/LoginGraphObject.kt
@@ -85,9 +85,6 @@ object LoginGraphObject {
             composable(
                 route = LoginRoutes.AnalyticsOptIn.getRoute()
             ) {
-                BackHandler(true) {
-                    // do nothing
-                }
                 OptInScreen()
             }
         }

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BioOptInAnalyticsViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BioOptInAnalyticsViewModel.kt
@@ -30,6 +30,7 @@ class BioOptInAnalyticsViewModel @Inject constructor(
             context,
             R.string.app_enablePasscodeOrPatternButton
         )
+    private val backBtnEvent = makeBackButtonEvent(context)
 
     fun trackBioOptInScreen() {
         analyticsLogger.logEventV3Dot1(screenEvent)
@@ -41,6 +42,10 @@ class BioOptInAnalyticsViewModel @Inject constructor(
 
     fun trackPasscodeButton() {
         analyticsLogger.logEventV3Dot1(passcodeBtnEvent)
+    }
+
+    fun trackBackButton() {
+        analyticsLogger.logEventV3Dot1(backBtnEvent)
     }
 
     companion object {
@@ -55,6 +60,13 @@ class BioOptInAnalyticsViewModel @Inject constructor(
         internal fun makeButtonEvent(context: Context, text: Int) = with(context) {
             TrackEvent.Button(
                 text = getEnglishString(text),
+                params = requiredParams
+            )
+        }
+
+        internal fun makeBackButtonEvent(context: Context) = with(context) {
+            TrackEvent.Button(
+                text = getEnglishString(R.string.system_backButton),
                 params = requiredParams
             )
         }

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BiometricsOptInScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BiometricsOptInScreen.kt
@@ -1,5 +1,7 @@
 package uk.gov.onelogin.features.login.ui.signin.biooptin
 
+import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -36,7 +39,14 @@ fun BiometricsOptInScreen(
     viewModel: BioOptInViewModel = hiltViewModel(),
     analyticsViewModel: BioOptInAnalyticsViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current as Activity
     LaunchedEffect(Unit) { analyticsViewModel.trackBioOptInScreen() }
+    BackHandler {
+        // Log GA4 event
+        analyticsViewModel.trackBackButton()
+        // Close app
+        context.finishAndRemoveTask()
+    }
     GdsTheme {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/splash/SplashScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/splash/SplashScreen.kt
@@ -63,7 +63,10 @@ fun SplashScreen(
     val loading = viewModel.loading.collectAsState()
     val unlock = viewModel.showUnlock.collectAsState()
 
-    BackHandler { analyticsViewModel.trackBackButton(context, unlock.value) }
+    BackHandler {
+        analyticsViewModel.trackBackButton(context, unlock.value)
+        context.finishAndRemoveTask()
+    }
     SideEffect { analyticsViewModel.trackSplashScreen(context, unlock.value) }
 
     SplashBody(

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
@@ -64,8 +64,8 @@ fun WelcomeScreen(
         }
     }
 
-    BackHandler(enabled = false) {
-        // Nothing to do
+    BackHandler(enabled = true) {
+        context.finishAndRemoveTask()
     }
     LaunchedEffect(key1 = Unit) {
         if (!shouldTryAgain()) return@LaunchedEffect

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.features.login.ui.signin.welcome
 
 import android.app.Activity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -59,10 +60,13 @@ fun WelcomeScreen(
     )
     if (loading.value) {
         LoadingScreen(loadingAnalyticsViewModel) {
-            // Nothing to do
+            viewModel.abortLogin(launcher)
         }
     }
 
+    BackHandler(enabled = false) {
+        // Nothing to do
+    }
     LaunchedEffect(key1 = Unit) {
         if (!shouldTryAgain()) return@LaunchedEffect
         if (viewModel.onlineChecker.isOnline()) {

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -90,6 +91,11 @@ class WelcomeScreenViewModel @Inject constructor(
                 }
             )
         }
+    }
+
+    fun abortLogin(launcher: ActivityResultLauncher<Intent>) {
+        _loading.value = false
+        onPrimary(launcher).cancel()
     }
 
     private fun CoroutineScope.handleLoginErrors(

--- a/features/src/main/java/uk/gov/onelogin/features/optin/ui/OptInScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/optin/ui/OptInScreen.kt
@@ -1,5 +1,6 @@
 package uk.gov.onelogin.features.optin.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -33,6 +34,7 @@ import uk.gov.onelogin.core.ui.meta.ScreenPreview
 fun OptInScreen(viewModel: OptInViewModel = hiltViewModel()) {
     val uriHandler = LocalUriHandler.current
     val state = viewModel.uiState.collectAsState(OptInUIState.PreChoice)
+    BackHandler(enabled = true) { viewModel.goToSignIn() }
     GdsTheme {
         OptInBody(
             uiState = state.value,

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutScreen.kt
@@ -27,11 +27,11 @@ fun SignOutScreen(
 ) {
     val loading by viewModel.loadingState.collectAsState()
     // Needed for deleteWalletData
-    val fragmentActivity = LocalContext.current as FragmentActivity
+    val context = LocalContext.current as FragmentActivity
 
     if (loading) {
         LoadingScreen(loadingAnalyticsViewModel) {
-            fragmentActivity.finish()
+            context.finishAndRemoveTask()
         }
     } else {
         SignOutBody(
@@ -42,7 +42,7 @@ fun SignOutScreen(
             },
             onPrimary = {
                 analyticsViewModel.trackPrimary()
-                viewModel.signOut(fragmentActivity)
+                viewModel.signOut(context)
             }
         )
         analyticsViewModel.trackSignOutView(viewModel.uiState)

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/biooptin/BioOptInAnalyticsViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/biooptin/BioOptInAnalyticsViewModelTest.kt
@@ -26,6 +26,7 @@ class BioOptInAnalyticsViewModelTest {
     private lateinit var id: String
     private lateinit var passcodeBtn: String
     private lateinit var biometricsBtn: String
+    private lateinit var backBtn: String
     private lateinit var requiredParameters: RequiredParameters
     private lateinit var logger: AnalyticsLogger
     private lateinit var viewModel: BioOptInAnalyticsViewModel
@@ -42,6 +43,7 @@ class BioOptInAnalyticsViewModelTest {
         id = context.getEnglishString(R.string.bio_opt_in_screen_page_id)
         passcodeBtn = context.getEnglishString(R.string.app_enablePasscodeOrPatternButton)
         biometricsBtn = context.getEnglishString(R.string.app_enableBiometricsButton)
+        backBtn = context.getEnglishString(R.string.system_backButton)
         viewModel = BioOptInAnalyticsViewModel(context, logger)
     }
 
@@ -72,11 +74,30 @@ class BioOptInAnalyticsViewModelTest {
                     viewModel.trackPasscodeButton()
                 },
                 text = passcodeBtn
+            ),
+            TestUtils.TrackEventTestCase.Button(
+                trackFunction = {
+                    viewModel.trackBackButton()
+                },
+                text = backBtn
             )
         ).forEach {
             val result = executeTrackEventTestCase(it, requiredParameters)
 
             verify(logger).logEventV3Dot1(result)
         }
+    }
+
+    @Test
+    fun trackBackButton() {
+        val event = ViewEvent.Screen(
+            name = name,
+            id = id,
+            params = requiredParameters
+        )
+
+        viewModel.trackBioOptInScreen()
+
+        verify(logger).logEventV3Dot1(event)
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/biooptin/BioOptInScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/biooptin/BioOptInScreenTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
 import uk.gov.onelogin.core.navigation.data.MainNavRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
@@ -83,5 +84,23 @@ class BioOptInScreenTest : FragmentActivityTestCase() {
         composeTestRule.onNode(secondaryButton).performClick()
 
         verify(navigator).navigate(MainNavRoutes.Start, true)
+    }
+
+    @Test
+    fun testBackButton() {
+        composeTestRule.setContent {
+            BiometricsOptInScreen(viewModel, analyticsViewModel)
+        }
+        composeTestRule.apply {
+            activityRule.scenario.onActivity { activity ->
+                activity.onBackPressedDispatcher.onBackPressed()
+            }
+
+            activityRule.scenario.onActivity { activity ->
+                assert(activity.isFinishing)
+            }
+        }
+
+        verify(analytics).logEventV3Dot1(BioOptInAnalyticsViewModel.makeBackButtonEvent(context))
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/splash/SplashScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/splash/SplashScreenTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.whenever
 import org.mockito.kotlin.wheneverBlocking
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.core.tokens.data.LocalAuthStatus
@@ -159,5 +160,25 @@ class SplashScreenTest : FragmentActivityTestCase() {
         composeTestRule.onNode(splashIcon).assertIsDisplayed()
         composeTestRule.onNode(loadingText).assertIsDisplayed()
         composeTestRule.onNode(loadingIndicator).assertIsDisplayed()
+    }
+
+    @Test
+    fun testBackButton() {
+        composeTestRule.setContent {
+            SplashScreen(viewModel, analyticsViewModel, optInViewModel)
+        }
+        composeTestRule.apply {
+            activityRule.scenario.onActivity { activity ->
+                activity.onBackPressedDispatcher.onBackPressed()
+            }
+
+            activityRule.scenario.onActivity { activity ->
+                assert(activity.isFinishing)
+            }
+        }
+
+        verify(analytics).logEventV3Dot1(
+            SplashScreenAnalyticsViewModel.makeBackEvent(context, false)
+        )
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
@@ -246,9 +246,8 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
         composeTestRule.apply {
             activityRule.scenario.onActivity { activity ->
                 activity.onBackPressedDispatcher.onBackPressed()
+                assert(activity.isFinishing)
             }
-
-            composeTestRule.onNode(signInButton).assertIsDisplayed()
         }
     }
 

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
@@ -228,6 +228,30 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
         verify(analytics).logEventV3Dot1(event)
     }
 
+    @Test
+    fun testBackButton() {
+        composeTestRule.setContent {
+            whenever(onlineChecker.isOnline()).thenReturn(true)
+            WelcomeScreen(
+                analyticsViewModel = analyticsViewModel,
+                viewModel = viewModel,
+                loadingAnalyticsViewModel = loadingAnalyticsVM,
+                shouldTryAgain = {
+                    shouldTryAgainCalled = true
+                    false
+                }
+            )
+        }
+
+        composeTestRule.apply {
+            activityRule.scenario.onActivity { activity ->
+                activity.onBackPressedDispatcher.onBackPressed()
+            }
+
+            composeTestRule.onNode(signInButton).assertIsDisplayed()
+        }
+    }
+
     private fun whenWeClickSignIn() {
         composeTestRule.onNode(signInButton).performClick()
     }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -4,7 +4,10 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.fragment.app.FragmentActivity
+import kotlin.test.assertFalse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -430,5 +433,21 @@ class WelcomeScreenViewModelTest {
         viewModel.navigateToOfflineError()
 
         verify(mockNavigator).navigate(ErrorRoutes.Offline, false)
+    }
+
+    @Test
+    fun `check abort login works as expected`() = runTest {
+        val mockIntent: Intent = mock()
+
+        whenever(mockHandleLoginRedirect.handle(eq(mockIntent), any(), any()))
+            .thenAnswer {
+                runBlocking {
+                    delay(10000)
+                    assert(viewModel.loading.value)
+                    viewModel.abortLogin(any())
+                }
+            }
+
+        assertFalse(viewModel.loading.value)
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/optin/ui/OptInScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/optin/ui/OptInScreenTest.kt
@@ -115,6 +115,20 @@ class OptInScreenTest : FragmentActivityTestCase() {
     }
 
     @Test
+    fun testBackButton() {
+        // Given the OptOutScreen Composable
+        composeTestRule.setContent {
+            OptInScreen(viewModel)
+        }
+
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            activity.onBackPressedDispatcher.onBackPressed()
+        }
+
+        verify(mockNavigator).navigate(LoginRoutes.Welcome, true)
+    }
+
+    @Test
     fun previewTest() {
         composeTestRule.setContent {
             OptInPreview()


### PR DESCRIPTION
# DCMAW-11019

**Description Of Changes:** 
- update the system back button for login screens (including `WelcomeScreen`, `BiometricsOptInScreen`, `SplashScreen` and the nav graph
- update sign out back button behviour on `SignOuScreen` and `ErrorGraphObject`
- add missing analytics GA4 event for `BiometricsOptInScreen`

**Evidence:**
The only behaviour for these screens that could not be met is the one on login redirect loading screen(point 5 in teh documentation) - at the moment the back-button is enable now, so it will go back to the `WebView` - the landing page on redirect is just a composable popped on top of the welcome screen - although the launcher job is getting cancelled when pressing back, the `handleLoginRedirect` is not a job. We can maybe disable the back button to not get this weird behaviour - or might need more time to look into how we could force the cancellation of handling the redirect.

https://github.com/user-attachments/assets/6b6eed1c-c2c8-46ec-8bca-ee8191a5d764


**Documentation:**
https://govukverify.atlassian.net/wiki/spaces/DCMAW/pages/4106388251/Strategic+App+Android+Hardware+back+button+behaviour

**Definition Of Done Checklist:**

- [ ] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [ ] Relevant integration and end-to-end tests are written
- [ ] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [ ] Sonar coverage gates met 
- [ ] If feature flagged, Feature is enabled in staging and manually tested to ensure integration

Resolves: DCMAW-11019