### PR TITLE
fix: DCMAW-11880 update to latest auth version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -113,7 +113,7 @@ pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
 componentsv2 = { group = "uk.gov.android", name = "componentsv2", version.ref = "govuk-ui" }
 patterns = { group = "uk.gov.android", name = "patterns", version.ref = "govuk-ui" }
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
-authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.15.0" }
+authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.17.0" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.8.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.3.4" }
 logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }


### PR DESCRIPTION
### [DCMAW-11880](https://govukverify.atlassian.net/browse/DCMAW-11880)

### Description

Simply bumping to next version to include addition of `typ` header changes

### Evidence

https://github.com/user-attachments/assets/a1b07a81-d637-471a-9bd6-a291bba8e633


[DCMAW-11880]: https://govukverify.atlassian.net/browse/DCMAW-11880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ