### PR TITLE
ci: Update dpeendabot to group patches and minors updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
     schedule:
       interval: weekly
       day: sunday
+      groups:
+        bundler-minor-versions:
+          patterns:
+            - "*"
+          update-types:
+            - minor
+            - patch
     open-pull-requests-limit: 5
 
   - package-ecosystem: gradle
@@ -30,3 +37,6 @@ updates:
         patterns:
           - "org.jetbrains.kotlin*"
           - "com.google.devtools.ksp*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
- update dependabot to group minor and patches into one PR rather than individual ones for each update/ upgrade