### PR TITLE
ci: Format wrong indentation for `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,13 +17,13 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-      groups:
-        bundler-minor-versions:
-          patterns:
-            - "*"
-          update-types:
-            - minor
-            - patch
+    groups:
+      bundler-minor-versions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     open-pull-requests-limit: 5
 
   - package-ecosystem: gradle


### PR DESCRIPTION
- amend wrong indentation on previous update