### PR TITLE
build: Update Wallet Sdk version to latest

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -39,7 +39,6 @@ class MainActivityViewModel @Inject constructor(
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
-        println("OnPause was called")
         if (isLocalAuthEnabled() &&
             tokenRepository.getTokenResponse() != null
         ) {

--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -39,6 +39,7 @@ class MainActivityViewModel @Inject constructor(
 
     override fun onPause(owner: LifecycleOwner) {
         super.onPause(owner)
+        println("OnPause was called")
         if (isLocalAuthEnabled() &&
             tokenRepository.getTokenResponse() != null
         ) {

--- a/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
@@ -2,7 +2,7 @@ package uk.gov.onelogin.navigation.graphs
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.compose.ui.platform.LocalContext
+import androidx.activity.compose.LocalActivity
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -30,7 +30,7 @@ object ErrorGraphObject {
             composable(
                 route = ErrorRoutes.SignOut.getRoute()
             ) {
-                val context = LocalContext.current as Activity
+                val context = LocalActivity.current as Activity
                 SignOutErrorScreen {
                     context.finishAndRemoveTask()
                 }
@@ -53,7 +53,7 @@ object ErrorGraphObject {
             composable(
                 route = ErrorRoutes.UpdateRequired.getRoute()
             ) {
-                val context = LocalContext.current as Activity
+                val context = LocalActivity.current as Activity
                 BackHandler(enabled = true) {
                     // Close/ terminate the app
                     context.finishAndRemoveTask()

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BiometricsOptInScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/biooptin/BiometricsOptInScreen.kt
@@ -2,6 +2,7 @@ package uk.gov.onelogin.features.login.ui.signin.biooptin
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,7 +15,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -39,7 +39,7 @@ fun BiometricsOptInScreen(
     viewModel: BioOptInViewModel = hiltViewModel(),
     analyticsViewModel: BioOptInAnalyticsViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current as Activity
+    val context = LocalActivity.current as Activity
     LaunchedEffect(Unit) { analyticsViewModel.trackBioOptInScreen() }
     BackHandler {
         // Log GA4 event

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/splash/SplashScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/splash/SplashScreen.kt
@@ -1,6 +1,7 @@
 package uk.gov.onelogin.features.login.ui.signin.splash
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -22,7 +23,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -58,7 +58,7 @@ fun SplashScreen(
     analyticsViewModel: SplashScreenAnalyticsViewModel = hiltViewModel(),
     optInRequirementViewModel: OptInRequirementViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current as FragmentActivity
+    val context = LocalActivity.current as FragmentActivity
     val lifecycleOwner = LocalLifecycleOwner.current
     val loading = viewModel.loading.collectAsState()
     val unlock = viewModel.showUnlock.collectAsState()

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
@@ -2,13 +2,13 @@ package uk.gov.onelogin.features.login.ui.signin.welcome
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -32,14 +32,14 @@ fun WelcomeScreen(
     shouldTryAgain: () -> Boolean = { false }
 ) {
     val loading = viewModel.loading.collectAsState()
-    val context = LocalContext.current as FragmentActivity
+    val context = LocalActivity.current as FragmentActivity
     val launcher =
         rememberLauncherForActivityResult(
             ActivityResultContracts.StartActivityForResult()
         ) { result: ActivityResult ->
             if (result.resultCode == Activity.RESULT_OK) {
                 result.data?.let { intent ->
-                    viewModel.handleActivityResult(intent = intent, fragmentActivity = context)
+                    viewModel.handleActivityResult(intent = intent)
                 }
             }
         }

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -70,8 +69,7 @@ class WelcomeScreenViewModel @Inject constructor(
 
     fun handleActivityResult(
         intent: Intent,
-        isReAuth: Boolean = false,
-        fragmentActivity: FragmentActivity
+        isReAuth: Boolean = false
     ) {
         if (intent.data == null) return
 
@@ -86,7 +84,7 @@ class WelcomeScreenViewModel @Inject constructor(
                 },
                 onFailure = {
                     Log.e(tag, it?.message, it)
-                    handleLoginErrors(it, fragmentActivity)
+                    handleLoginErrors(it)
                 }
             )
         }
@@ -97,16 +95,13 @@ class WelcomeScreenViewModel @Inject constructor(
         onPrimary(launcher).cancel()
     }
 
-    private fun CoroutineScope.handleLoginErrors(
-        it: Throwable?,
-        fragmentActivity: FragmentActivity
-    ) {
+    private fun CoroutineScope.handleLoginErrors(it: Throwable?) {
         this.launch {
             when (it) {
                 is AuthenticationError -> {
                     when (it.type) {
                         AuthenticationError.ErrorType.ACCESS_DENIED -> {
-                            signOutUseCase.invoke(fragmentActivity)
+                            signOutUseCase.invoke()
                             navigator.navigate(SignOutRoutes.ReAuthError)
                         }
                         else -> navigator.navigate(LoginRoutes.SignInError, true)

--- a/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCase.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCase.kt
@@ -1,7 +1,5 @@
 package uk.gov.onelogin.features.signout.domain
 
-import androidx.fragment.app.FragmentActivity
-
 fun interface SignOutUseCase {
-    suspend fun invoke(activityFragment: FragmentActivity)
+    suspend fun invoke()
 }

--- a/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseImpl.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.features.signout.domain
 
-import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
 import uk.gov.onelogin.core.cleaner.domain.Cleaner
 import uk.gov.onelogin.features.wallet.domain.DeleteWalletDataUseCase
@@ -11,10 +10,10 @@ class SignOutUseCaseImpl @Inject constructor(
     private val deleteWalletData: DeleteWalletDataUseCase
 ) : SignOutUseCase {
     @Throws(SignOutError::class)
-    override suspend fun invoke(activityFragment: FragmentActivity) {
+    override suspend fun invoke() {
         try {
             cleaner.clean()
-            deleteWalletData.invoke(activityFragment)
+            deleteWalletData.invoke()
         } catch (e: Throwable) {
             throw SignOutError(e)
         }

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutScreen.kt
@@ -1,10 +1,10 @@
 package uk.gov.onelogin.features.signout.ui
 
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -26,8 +26,7 @@ fun SignOutScreen(
     loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel = hiltViewModel()
 ) {
     val loading by viewModel.loadingState.collectAsState()
-    // Needed for deleteWalletData
-    val context = LocalContext.current as FragmentActivity
+    val context = LocalActivity.current as FragmentActivity
 
     if (loading) {
         LoadingScreen(loadingAnalyticsViewModel) {
@@ -42,7 +41,7 @@ fun SignOutScreen(
             },
             onPrimary = {
                 analyticsViewModel.trackPrimary()
-                viewModel.signOut(context)
+                viewModel.signOut()
             }
         )
         analyticsViewModel.trackSignOutView(viewModel.uiState)

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutViewModel.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.features.signout.ui
 
 import android.util.Log
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -34,11 +33,11 @@ class SignOutViewModel @Inject constructor(
             SignOutUIState.NoWallet
         }
 
-    fun signOut(activityFragment: FragmentActivity) {
+    fun signOut() {
         _loadingState.value = true
         viewModelScope.launch {
             try {
-                signOutUseCase.invoke(activityFragment)
+                signOutUseCase.invoke()
                 navigator.navigate(LoginRoutes.Root, true)
             } catch (e: SignOutError) {
                 Log.e(this::class.simpleName, e.message, e)

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
-import androidx.fragment.app.FragmentActivity
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -37,7 +35,6 @@ fun SignedOutInfoScreen(
     shouldTryAgain: () -> Boolean = { false }
 ) {
     val loading by loginViewModel.loading.collectAsState()
-    val activity = LocalContext.current as FragmentActivity
     val launcher =
         rememberLauncherForActivityResult(
             ActivityResultContracts.StartActivityForResult()
@@ -46,8 +43,7 @@ fun SignedOutInfoScreen(
                 result.data?.let { intent ->
                     loginViewModel.handleActivityResult(
                         intent = intent,
-                        isReAuth = signOutViewModel.shouldReAuth(),
-                        fragmentActivity = activity
+                        isReAuth = signOutViewModel.shouldReAuth()
                     )
                     signOutViewModel.saveTokens()
                 }
@@ -62,8 +58,7 @@ fun SignedOutInfoScreen(
         handleLogin(
             loginViewModel,
             signOutViewModel,
-            launcher,
-            activity
+            launcher
         )
     }
 
@@ -75,8 +70,7 @@ fun SignedOutInfoScreen(
             handleLogin(
                 loginViewModel,
                 signOutViewModel,
-                launcher,
-                activity
+                launcher
             )
         }
     }
@@ -93,11 +87,10 @@ fun SignedOutInfoScreen(
 private fun handleLogin(
     loginViewModel: WelcomeScreenViewModel,
     signOutViewModel: SignedOutInfoViewModel,
-    launcher: ActivityResultLauncher<Intent>,
-    activity: FragmentActivity
+    launcher: ActivityResultLauncher<Intent>
 ) {
     if (loginViewModel.onlineChecker.isOnline()) {
-        signOutViewModel.checkPersistentId(activity) {
+        signOutViewModel.checkPersistentId {
             loginViewModel.onPrimary(launcher)
         }
     } else {

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModel.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.features.signout.ui
 
 import android.util.Log
-import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,13 +38,12 @@ class SignedOutInfoViewModel @Inject constructor(
     fun shouldReAuth() = navigator.hasBackStack()
 
     fun checkPersistentId(
-        activity: FragmentActivity,
         callback: () -> Unit
     ) {
         viewModelScope.launch {
             if (getPersistentId().isNullOrEmpty()) {
                 try {
-                    signOutUseCase.invoke(activity)
+                    signOutUseCase.invoke()
                     navigator.navigate(SignOutRoutes.ReAuthError, true)
                 } catch (error: SignOutError) {
                     Log.e(this::class.simpleName, error.message, error)

--- a/features/src/main/java/uk/gov/onelogin/features/wallet/domain/DeleteWalletDataUseCase.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/wallet/domain/DeleteWalletDataUseCase.kt
@@ -1,18 +1,17 @@
 package uk.gov.onelogin.features.wallet.domain
 
-import androidx.fragment.app.FragmentActivity
 import javax.inject.Inject
 import uk.gov.android.wallet.sdk.WalletSdk
 
 fun interface DeleteWalletDataUseCase {
-    suspend fun invoke(activityFragment: FragmentActivity)
+    suspend fun invoke()
 }
 
 class DeleteWalletDataUseCaseImpl @Inject constructor(
     private val walletSdk: WalletSdk
 ) : DeleteWalletDataUseCase {
-    override suspend fun invoke(activityFragment: FragmentActivity) {
-        val deleteResult = walletSdk.deleteWalletData(activityFragment)
+    override suspend fun invoke() {
+        val deleteResult = walletSdk.deleteWalletData()
         if (!deleteResult) throw DeleteWalletDataError()
     }
 

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -3,7 +3,6 @@ package uk.gov.onelogin.features.login.ui.welcome
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertFalse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -48,7 +47,6 @@ import uk.gov.onelogin.features.signout.domain.SignOutUseCase
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class WelcomeScreenViewModelTest {
     private val mockContext: Context = mock()
-    private val mockFragmentActivity: FragmentActivity = mock()
     private val mockCredChecker: CredentialChecker = mock()
     private val mockBioPrefHandler: BiometricPreferenceHandler = mock()
     private val mockTokenRepository: TokenRepository = mock()
@@ -121,8 +119,7 @@ class WelcomeScreenViewModelTest {
                 .thenReturn(true)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verify(mockTokenRepository).setTokenResponse(tokenResponse)
@@ -152,8 +149,7 @@ class WelcomeScreenViewModelTest {
 
             // re-authenticate is false by default
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verify(mockTokenRepository).setTokenResponse(tokenResponse)
@@ -180,8 +176,7 @@ class WelcomeScreenViewModelTest {
                 .thenReturn(true)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
@@ -208,8 +203,7 @@ class WelcomeScreenViewModelTest {
             whenever(mockBioPrefHandler.getBioPref()).thenReturn(BiometricPreference.NONE)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
@@ -234,8 +228,7 @@ class WelcomeScreenViewModelTest {
                 .thenReturn(true)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verifyNoInteractions(mockSaveTokens)
@@ -262,8 +255,7 @@ class WelcomeScreenViewModelTest {
 
             viewModel.handleActivityResult(
                 mockIntent,
-                true,
-                fragmentActivity = mockFragmentActivity
+                true
             )
 
             verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
@@ -290,8 +282,7 @@ class WelcomeScreenViewModelTest {
 
             viewModel.handleActivityResult(
                 mockIntent,
-                true,
-                fragmentActivity = mockFragmentActivity
+                true
             )
 
             verify(mockSaveTokenExpiry).invoke(tokenResponse.accessTokenExpirationTime)
@@ -319,11 +310,10 @@ class WelcomeScreenViewModelTest {
 
             viewModel.handleActivityResult(
                 mockIntent,
-                true,
-                fragmentActivity = mockFragmentActivity
+                true
             )
 
-            verify(mockSignOutUseCase).invoke(mockFragmentActivity)
+            verify(mockSignOutUseCase).invoke()
             verify(mockNavigator).navigate(SignOutRoutes.ReAuthError)
         }
 
@@ -345,8 +335,7 @@ class WelcomeScreenViewModelTest {
 
             viewModel.handleActivityResult(
                 mockIntent,
-                true,
-                fragmentActivity = mockFragmentActivity
+                true
             )
 
             verifyNoInteractions(mockSignOutUseCase)
@@ -360,8 +349,7 @@ class WelcomeScreenViewModelTest {
             whenever(mockIntent.data).thenReturn(null)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verifyNoInteractions(mockSaveTokens)
@@ -384,8 +372,7 @@ class WelcomeScreenViewModelTest {
                 }
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verifyNoInteractions(mockSaveTokens)
@@ -410,8 +397,7 @@ class WelcomeScreenViewModelTest {
                 .thenReturn(false)
 
             viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
+                mockIntent
             )
 
             verifyNoInteractions(mockSaveTokens)

--- a/features/src/test/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.features.signout.domain
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +23,6 @@ import uk.gov.onelogin.features.wallet.domain.DeleteWalletDataUseCaseImpl.Compan
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(InstantExecutorExtension::class, CoroutinesTestExtension::class)
 class SignOutUseCaseTest {
-    private val activityFragment: FragmentActivity = mock()
     private val deleteWalletData: DeleteWalletDataUseCase = mock()
     private lateinit var useCase: SignOutUseCase
 
@@ -46,19 +44,19 @@ class SignOutUseCaseTest {
                     ),
                     deleteWalletData
                 )
-            useCase.invoke(activityFragment)
+            useCase.invoke()
             // Then it clears all the required data
             verify(removeTokenExpiry).clean()
             verify(removeAllSecureStoreData).clean()
             verify(bioPrefHandler).clean()
-            verify(deleteWalletData).invoke(activityFragment)
+            verify(deleteWalletData).invoke()
         }
 
     @Test
     fun `sign out delete wallet data error`() =
         runTest {
             // When invoking the sign out use case
-            whenever(deleteWalletData.invoke(activityFragment)).then {
+            whenever(deleteWalletData.invoke()).then {
                 throw DeleteWalletDataUseCaseImpl.DeleteWalletDataError()
             }
 
@@ -74,7 +72,7 @@ class SignOutUseCaseTest {
             // Then throw SignOutError
             val exception =
                 assertThrows<SignOutError> {
-                    useCase.invoke(activityFragment)
+                    useCase.invoke()
                 }
             assertTrue(exception.error.message!!.contains(DELETE_WALLET_DATA_ERROR))
         }
@@ -98,7 +96,7 @@ class SignOutUseCaseTest {
             // Then throw SignOutError
             val exception =
                 assertThrows<SignOutError> {
-                    useCase.invoke(activityFragment)
+                    useCase.invoke()
                 }
             assertTrue(exception.error.message!!.contains(errorMessage))
         }

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutScreenTest.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -105,7 +104,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
 
         composeTestRule.onNodeWithTag(LOADING_SCREEN_PROGRESS_INDICATOR).assertIsDisplayed()
         verify(analytics).logEventV3Dot1(SignOutAnalyticsViewModel.onPrimaryEvent(context))
-        verify(signOutUseCase).invoke(any())
+        verify(signOutUseCase).invoke()
         verify(navigator).navigate(LoginRoutes.Root, true)
     }
 
@@ -118,10 +117,10 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
-        whenever(signOutUseCase.invoke(any()))
+        whenever(signOutUseCase.invoke())
             .thenThrow(SignOutError(Exception("something went wrong")))
         composeTestRule.onNode(button).performClick()
-        verify(signOutUseCase).invoke(any())
+        verify(signOutUseCase).invoke()
         verify(navigator).navigate(ErrorRoutes.SignOut, true)
     }
 

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutViewModelTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.features.signout.ui
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -27,7 +26,6 @@ class SignOutViewModelTest {
     private lateinit var viewModel: SignOutViewModel
 
     private val mockNavigator: Navigator = mock()
-    private val mockActivity: FragmentActivity = mock()
     private val mockSignOutUseCase: SignOutUseCase = mock()
     private val featureFlags: FeatureFlags = mock()
 
@@ -45,20 +43,20 @@ class SignOutViewModelTest {
     @Test
     fun `sign out use case does not throw`() =
         runTest {
-            viewModel.signOut(mockActivity)
+            viewModel.signOut()
 
-            verify(mockSignOutUseCase).invoke(mockActivity)
+            verify(mockSignOutUseCase).invoke()
             verify(mockNavigator).navigate(LoginRoutes.Root, true)
         }
 
     @Test
     fun `sign out use case does throw`() =
         runTest {
-            whenever(mockSignOutUseCase.invoke(mockActivity)).thenThrow(SignOutError(Exception()))
+            whenever(mockSignOutUseCase.invoke()).thenThrow(SignOutError(Exception()))
 
-            viewModel.signOut(mockActivity)
+            viewModel.signOut()
 
-            verify(mockSignOutUseCase).invoke(mockActivity)
+            verify(mockSignOutUseCase).invoke()
             verify(mockNavigator).navigate(ErrorRoutes.SignOut, true)
         }
 

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreenTest.kt
@@ -175,7 +175,7 @@ class SignedOutInfoScreenTest : FragmentActivityTestCase() {
 
         whenWeClickSignIn()
 
-        verify(signOutUseCase).invoke(any())
+        verify(signOutUseCase).invoke()
         verify(navigator).navigate(SignOutRoutes.ReAuthError, true)
     }
 

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModelTest.kt
@@ -1,13 +1,11 @@
 package uk.gov.onelogin.features.signout.ui
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -84,12 +82,11 @@ class SignedOutInfoViewModelTest {
     fun `sign out usecase is called when persistent id is null`() =
         runTest {
             var callback = false
-            val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn(null)
 
-            viewModel.checkPersistentId(activity) { callback = true }
+            viewModel.checkPersistentId { callback = true }
 
-            verify(signOutUseCase).invoke(activity)
+            verify(signOutUseCase).invoke()
             verify(navigator).navigate(SignOutRoutes.ReAuthError, true)
         }
 
@@ -97,12 +94,11 @@ class SignedOutInfoViewModelTest {
     fun `sign out usecase is called when persistent id is empty`() =
         runTest {
             var callback = false
-            val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn("")
 
-            viewModel.checkPersistentId(activity) { callback = true }
+            viewModel.checkPersistentId { callback = true }
 
-            verify(signOutUseCase).invoke(activity)
+            verify(signOutUseCase).invoke()
             verify(navigator).navigate(SignOutRoutes.ReAuthError, true)
         }
 
@@ -110,11 +106,10 @@ class SignedOutInfoViewModelTest {
     fun `sign out usecase is not called when persistent id good and device secure`() =
         runTest {
             var callback = false
-            val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn("id")
             whenever(credentialChecker.isDeviceSecure()).thenReturn(true)
 
-            viewModel.checkPersistentId(activity) { callback = true }
+            viewModel.checkPersistentId { callback = true }
 
             verifyNoInteractions(signOutUseCase)
             verifyNoInteractions(navigator)
@@ -126,11 +121,10 @@ class SignedOutInfoViewModelTest {
     fun `sign out usecase is not called when persistent id good and device unsecure`() =
         runTest {
             var callback = false
-            val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn("id")
             whenever(credentialChecker.isDeviceSecure()).thenReturn(false)
 
-            viewModel.checkPersistentId(activity) { callback = true }
+            viewModel.checkPersistentId { callback = true }
 
             verifyNoInteractions(signOutUseCase)
             verifyNoInteractions(navigator)
@@ -142,13 +136,12 @@ class SignedOutInfoViewModelTest {
     fun `sign out usecase throws`() =
         runTest {
             var callback = false
-            val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn("")
-            whenever(signOutUseCase.invoke(any())).thenThrow(SignOutError(Error()))
+            whenever(signOutUseCase.invoke()).thenThrow(SignOutError(Error()))
 
-            viewModel.checkPersistentId(activity) { callback = true }
+            viewModel.checkPersistentId { callback = true }
 
-            verify(signOutUseCase).invoke(activity)
+            verify(signOutUseCase).invoke()
             verify(navigator).navigate(LoginRoutes.SignInError, true)
             assertFalse(callback)
         }

--- a/features/src/test/java/uk/gov/onelogin/features/wallet/domain/DeleteWalletDataUseCaseTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/wallet/domain/DeleteWalletDataUseCaseTest.kt
@@ -1,12 +1,10 @@
 package uk.gov.onelogin.features.wallet.domain
 
-import androidx.fragment.app.FragmentActivity
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.android.wallet.sdk.WalletSdk
@@ -15,26 +13,25 @@ import uk.gov.onelogin.features.wallet.domain.DeleteWalletDataUseCaseImpl.Compan
 
 class DeleteWalletDataUseCaseTest {
     private val walletSdk: WalletSdkImpl = mock()
-    private val activityFragment: FragmentActivity = mock()
     private val sut = DeleteWalletDataUseCaseImpl(walletSdk)
 
     @Test
     fun `delete wallet data success`() =
         runBlocking {
-            whenever(walletSdk.deleteWalletData(any())).thenReturn(true)
-            val result = sut.invoke(activityFragment)
+            whenever(walletSdk.deleteWalletData()).thenReturn(true)
+            val result = sut.invoke()
             assertEquals(Unit, result)
         }
 
     @Test
     fun `delete wallet data error`() =
         runBlocking {
-            whenever(walletSdk.deleteWalletData(any())).thenReturn(false)
+            whenever(walletSdk.deleteWalletData()).thenReturn(false)
             val result =
                 Assertions.assertThrows(
                     DeleteWalletDataUseCaseImpl.DeleteWalletDataError::class.java
                 ) {
-                    runBlocking { sut.invoke(activityFragment) }
+                    runBlocking { sut.invoke() }
                 }
             assertTrue(result.message.contains(DELETE_WALLET_DATA_ERROR))
         }
@@ -42,13 +39,13 @@ class DeleteWalletDataUseCaseTest {
     @Test
     fun `walled sdk init error`(): Unit =
         runBlocking {
-            whenever(walletSdk.deleteWalletData(any())).then {
+            whenever(walletSdk.deleteWalletData()).then {
                 throw WalletSdk.WalletSdkError.SdkNotInitialised
             }
             Assertions.assertThrows(
                 WalletSdk.WalletSdkError.SdkNotInitialised::class.java
             ) {
-                runBlocking { sut.invoke(activityFragment) }
+                runBlocking { sut.invoke() }
             }
         }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ classgraph = "4.8.179"
 govuk-ui = "7.18.0"
 govuk-logging = "0.20.0"
 compose-runtime = "1.7.8"
-wallet = "1.38.0"
+wallet = "1.66.0"
 cri-orchestrator = "0.9.2"
 junitVersion = "4.13.2"
 material = "1.12.0"
@@ -105,7 +105,7 @@ classgraph = { group = "io.github.classgraph", name = "classgraph", version.ref 
 roboelectric = { group = "org.robolectric", name = "robolectric", version = "4.14.1" }
 
 # GDS
-wallet-sdk = { module = "uk.gov.android.wallet:wallet_sdk", version.ref = "wallet" }
+wallet-sdk = { module = "uk.gov.android:wallet_sdk", version.ref = "wallet" }
 cri-orchestrator = { group = "uk.gov.onelogin.criorchestrator.sdk", name = "sdk", version.ref = "cri-orchestrator" }
 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }


### PR DESCRIPTION
**No ticket**

- replace `LocalContext.current` with `LocalActivity.current` when cast to either `Activity` of `FragmentActivity` - this is due to Wallet using `androidx.activity:activity` v1.10 or higher
- remove the activity required for `deleteAllDataUseCase` and all classes and functions that where passing activity for that only reason - it seems not to be required with the new sdk version

**Definition Of Done Checklist:**

- [x] Unit tests written to at least 80% code coverage (unless explicit approval given from TL that this is not necessary)
- [x] Relevant integration and end-to-end tests are written
- [x] Tests cover each acceptance criteria on the user story
- [ ] Demo completed by running code locally, demoing to a code reviewer & designer
- [x] Sonar coverage gates met 