### PR TITLE
feat: DCMAW-7903 secure store logging

### DIFF
--- a/app/src/androidTest/java/uk/gov/onelogin/mainnav/ui/MainNavScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/mainnav/ui/MainNavScreenTest.kt
@@ -22,6 +22,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.android.featureflags.FeatureFlags
 import uk.gov.android.onelogin.core.R
 import uk.gov.android.wallet.core.R as walletR
+import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.core.AnalyticsModule
@@ -44,6 +45,9 @@ class MainNavScreenTest : TestCase() {
 
     @BindValue
     var analytics: AnalyticsLogger = mock()
+
+    @BindValue
+    val logger: Logger = mock()
 
     @Test
     fun checkBottomOptionsDisplayed() {

--- a/app/src/main/java/uk/gov/onelogin/network/NetworkModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/NetworkModule.kt
@@ -17,6 +17,7 @@ import uk.gov.android.network.useragent.UserAgentGenerator
 import uk.gov.android.network.useragent.UserAgentGeneratorImpl
 import uk.gov.android.onelogin.BuildConfig
 import uk.gov.android.onelogin.core.R
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.core.network.domain.StsAuthenticationProvider
 import uk.gov.onelogin.core.tokens.data.TokenRepository
@@ -53,6 +54,7 @@ object NetworkModule {
         return userAgentGenerator
     }
 
+    @Suppress("LongParameterList")
     @Provides
     fun provideHttpClient(
         @ApplicationContext
@@ -60,7 +62,8 @@ object NetworkModule {
         userAgentGenerator: UserAgentGenerator,
         tokenRepository: TokenRepository,
         isAccessTokenExpired: IsAccessTokenExpired,
-        navigator: Navigator
+        navigator: Navigator,
+        logger: Logger
     ): GenericHttpClient {
         val client = KtorHttpClient(userAgentGenerator)
         val endpoint = context.getString(R.string.tokenExchangeEndpoint)
@@ -70,7 +73,8 @@ object NetworkModule {
             tokenRepository,
             isAccessTokenExpired,
             client,
-            navigator
+            navigator,
+            logger
         )
         client.setAuthenticationProvider(authProvider)
         return client

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -123,7 +123,8 @@ dependencies {
         libs.androidx.compose.ui.junit4,
         libs.androidx.espresso.core,
         libs.androidx.navigation.testing,
-        libs.androidx.test.orchestrator
+        libs.androidx.test.orchestrator,
+        libs.logging.test
     ).forEach(::testImplementation)
 
     listOf(

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -67,13 +67,10 @@ android {
                     suffix = ".$environment"
                 }
 
-                val packageName = "${project.android.namespace}$suffix"
-
                 manifestPlaceholders["flavorSuffix"] = suffix
             }
         }
     }
-    @Suppress("UnstableApiUsage")
     testOptions {
         unitTests.all {
             it.useJUnitPlatform()

--- a/core/src/main/java/uk/gov/onelogin/core/network/domain/StsAuthenticationProvider.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/network/domain/StsAuthenticationProvider.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.core.network.domain
 
-import android.util.Log
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.Parameters
 import kotlinx.serialization.json.Json
@@ -10,6 +9,7 @@ import uk.gov.android.network.api.ApiResponseException
 import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse
 import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.navigation.data.SignOutRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.core.tokens.data.TokenRepository
@@ -20,7 +20,8 @@ class StsAuthenticationProvider(
     private val tokenRepository: TokenRepository,
     private val isAccessTokenExpired: IsAccessTokenExpired,
     private val httpClient: GenericHttpClient,
-    private val navigator: Navigator
+    private val navigator: Navigator,
+    private val logger: Logger
 ) : AuthenticationProvider {
     @Suppress("TooGenericExceptionCaught")
     override suspend fun fetchBearerToken(scope: String): AuthenticationResponse {
@@ -59,7 +60,7 @@ class StsAuthenticationProvider(
                         .decodeFromString(tokenResponseString)
                     AuthenticationResponse.Success(tokenApiResponse.token)
                 } catch (e: Exception) {
-                    Log.e(this::class.java.simpleName, e.message, e)
+                    logger.error(this::class.java.simpleName, e.message.toString(), e)
                     AuthenticationResponse.Failure(e)
                 }
             } else {

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/VerifyIdToken.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/VerifyIdToken.kt
@@ -85,7 +85,6 @@ class VerifyIdTokenImpl @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            println("here")
             logger.error(this::class.java.simpleName, e.toString(), e)
         }
         return null

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/VerifyIdToken.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/VerifyIdToken.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.core.tokens.domain
 
-import android.util.Log
 import javax.inject.Inject
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.Base64.PaddingOption
@@ -12,18 +11,23 @@ import uk.gov.android.authentication.json.jwt.JwtVerifier
 import uk.gov.android.network.api.ApiRequest
 import uk.gov.android.network.api.ApiResponse
 import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.logging.api.Logger
 
-fun interface VerifyIdToken {
+interface VerifyIdToken {
     suspend operator fun invoke(
         idToken: String,
         jwksUrl: String
     ): Boolean
+
+    fun extractEmailFromIdToken(idToken: String): String?
+    fun extractPersistentIdFromIdToken(idToken: String): String?
 }
 
 @Suppress("TooGenericExceptionCaught")
 class VerifyIdTokenImpl @Inject constructor(
     private val httpClient: GenericHttpClient,
-    private val verifier: JwtVerifier
+    private val verifier: JwtVerifier,
+    private val logger: Logger
 ) : VerifyIdToken {
     override suspend fun invoke(
         idToken: String,
@@ -33,7 +37,8 @@ class VerifyIdTokenImpl @Inject constructor(
         return verified
     }
 
-    private fun isEmailValid(idToken: String): Boolean = idToken.extractEmailFromIdToken() != null
+    private fun isEmailValid(idToken: String): Boolean =
+        extractEmailFromIdToken(idToken) != null
 
     private suspend fun isIdTokenValid(
         jwksUrl: String,
@@ -47,7 +52,7 @@ class VerifyIdTokenImpl @Inject constructor(
             try {
                 verified = useJwksResponseToVerify(response.response.toString(), idToken)
             } catch (e: Exception) {
-                Log.e(this::class.simpleName, e.message, e)
+                logger.error(this::class.java.simpleName, e.toString(), e)
             }
         }
         return verified
@@ -80,7 +85,8 @@ class VerifyIdTokenImpl @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            Log.e(this::class.simpleName, e.message, e)
+            println("here")
+            logger.error(this::class.java.simpleName, e.toString(), e)
         }
         return null
     }
@@ -94,41 +100,41 @@ class VerifyIdTokenImpl @Inject constructor(
             // the kid returned here will be surrounded by double quotes
             return data.jsonObject["kid"].toString()
         } catch (e: Exception) {
-            Log.e(this::class.simpleName, e.message, e)
+            logger.error(this::class.java.simpleName, e.toString(), e)
             return null
         }
     }
-}
 
-@OptIn(ExperimentalEncodingApi::class)
-@Suppress("TooGenericExceptionCaught")
-fun String.extractEmailFromIdToken(): String? {
-    try {
-        val bodyEncoded = this.split(".")[1]
-        val body = String(Base64.withPadding(PaddingOption.PRESENT_OPTIONAL).decode(bodyEncoded))
-        val data = Json.parseToJsonElement(body)
-        val email = data.jsonObject["email"]
-        println(email)
-        val stripEmail = email?.toString()?.removeSurrounding("\"")
-        return stripEmail
-    } catch (e: Exception) {
-        Log.e(this::class.simpleName, e.message, e)
-        return null
+    @OptIn(ExperimentalEncodingApi::class)
+    @Suppress("TooGenericExceptionCaught")
+    override fun extractEmailFromIdToken(idToken: String): String? {
+        try {
+            val bodyEncoded = idToken.split(".")[1]
+            val body =
+                String(Base64.withPadding(PaddingOption.PRESENT_OPTIONAL).decode(bodyEncoded))
+            val data = Json.parseToJsonElement(body)
+            val email = data.jsonObject["email"]
+            val stripEmail = email?.toString()?.removeSurrounding("\"")
+            return stripEmail
+        } catch (e: Exception) {
+            logger.error(this::class.java.simpleName, e.toString(), e)
+            return null
+        }
     }
-}
 
-@OptIn(ExperimentalEncodingApi::class)
-@Suppress("TooGenericExceptionCaught")
-fun String.extractPersistentIdFromIdToken(): String? {
-    try {
-        val bodyEncoded = this.split(".")[1]
-        val body = String(Base64.withPadding(PaddingOption.ABSENT).decode(bodyEncoded))
-        val data = Json.parseToJsonElement(body)
-        val id = data.jsonObject["persistent_id"]
-        val stripEmail = id?.toString()?.removeSurrounding("\"")
-        return stripEmail
-    } catch (e: Exception) {
-        Log.e(this::class.simpleName, e.message, e)
-        return null
+    @OptIn(ExperimentalEncodingApi::class)
+    @Suppress("TooGenericExceptionCaught")
+    override fun extractPersistentIdFromIdToken(idToken: String): String? {
+        try {
+            val bodyEncoded = idToken.split(".")[1]
+            val body = String(Base64.withPadding(PaddingOption.ABSENT).decode(bodyEncoded))
+            val data = Json.parseToJsonElement(body)
+            val id = data.jsonObject["persistent_id"]
+            val stripEmail = id?.toString()?.removeSurrounding("\"")
+            return stripEmail
+        } catch (e: Exception) {
+            logger.error(this::class.java.simpleName, e.toString(), e)
+            return null
+        }
     }
 }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/remove/RemoveAllSecureStoreData.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/remove/RemoveAllSecureStoreData.kt
@@ -1,10 +1,10 @@
 package uk.gov.onelogin.core.tokens.domain.remove
 
-import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.cleaner.domain.Cleaner
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 
@@ -12,7 +12,8 @@ interface RemoveAllSecureStoreData : Cleaner
 
 class RemoveAllSecureStoreDataImpl @Inject constructor(
     @Named("Token")
-    private val tokenSecureStore: SecureStore
+    private val tokenSecureStore: SecureStore,
+    private val logger: Logger
 ) : RemoveAllSecureStoreData {
     override suspend fun clean(): Result<Unit> {
         return try {
@@ -24,7 +25,7 @@ class RemoveAllSecureStoreDataImpl @Inject constructor(
             )
             Result.success(Unit)
         } catch (e: SecureStorageError) {
-            Log.e(this::class.simpleName, e.message, e)
+            logger.error(this::class.simpleName.toString(), e.message.toString(), e)
             Result.failure(e)
         }
     }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetEmailImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetEmailImpl.kt
@@ -2,14 +2,15 @@ package uk.gov.onelogin.core.tokens.domain.retrieve
 
 import javax.inject.Inject
 import uk.gov.onelogin.core.tokens.data.TokenRepository
-import uk.gov.onelogin.core.tokens.domain.extractEmailFromIdToken
+import uk.gov.onelogin.core.tokens.domain.VerifyIdToken
 
 class GetEmailImpl @Inject constructor(
-    val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    private val verifyIdToken: VerifyIdToken
 ) : GetEmail {
     override fun invoke(): String? {
         val idToken: String = tokenRepository.getTokenResponse()?.idToken ?: return null
-        val email = idToken.extractEmailFromIdToken()
+        val email = verifyIdToken.extractEmailFromIdToken(idToken)
         return email
     }
 }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromEncryptedSecureStoreImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromEncryptedSecureStoreImpl.kt
@@ -8,11 +8,13 @@ import uk.gov.android.securestore.RetrievalEvent
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.authentication.AuthenticatorPromptConfiguration
 import uk.gov.android.securestore.error.SecureStoreErrorType
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.tokens.data.LocalAuthStatus
 
 class GetFromEncryptedSecureStoreImpl @Inject constructor(
     @Named("Token")
-    private val secureStore: SecureStore
+    private val secureStore: SecureStore,
+    private val logger: Logger
 ) : GetFromEncryptedSecureStore {
     override suspend fun invoke(
         context: FragmentActivity,
@@ -33,6 +35,12 @@ class GetFromEncryptedSecureStoreImpl @Inject constructor(
             is RetrievalEvent.Success -> callback(LocalAuthStatus.Success(result.value))
 
             is RetrievalEvent.Failed -> {
+                logger.error(
+                    this::class.simpleName.toString(),
+                    "Secure store retrieval failed: " +
+                        "\ntype - ${result.type}" +
+                        "\nreason - ${result.reason}"
+                )
                 val localAuthStatus = when (result.type) {
                     SecureStoreErrorType.GENERAL -> LocalAuthStatus.SecureStoreError
 

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromOpenSecureStoreImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromOpenSecureStoreImpl.kt
@@ -1,19 +1,20 @@
 package uk.gov.onelogin.core.tokens.domain.retrieve
 
-import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
 import uk.gov.android.securestore.RetrievalEvent
 import uk.gov.android.securestore.SecureStore
+import uk.gov.logging.api.Logger
 
 class GetFromOpenSecureStoreImpl @Inject constructor(
     @Named("Open")
-    private val secureStore: SecureStore
+    private val secureStore: SecureStore,
+    private val logger: Logger
 ) : GetFromOpenSecureStore {
     override suspend fun invoke(vararg key: String): Map<String, String>? {
         return when (val retrievalEvent = secureStore.retrieve(*key)) {
             is RetrievalEvent.Failed -> {
-                Log.e(this::class.simpleName, "Reason: ${retrievalEvent.reason}")
+                logger.error(this::class.simpleName.toString(), "Reason: ${retrievalEvent.reason}")
                 null
             }
             is RetrievalEvent.Success -> retrievalEvent.value

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveToOpenSecureStoreImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveToOpenSecureStoreImpl.kt
@@ -1,14 +1,15 @@
 package uk.gov.onelogin.core.tokens.domain.save
 
-import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.api.Logger
 
 class SaveToOpenSecureStoreImpl @Inject constructor(
     @Named("Open")
-    private val secureStore: SecureStore
+    private val secureStore: SecureStore,
+    private val logger: Logger
 ) : SaveToOpenSecureStore {
     override suspend fun save(
         key: String,
@@ -20,7 +21,7 @@ class SaveToOpenSecureStoreImpl @Inject constructor(
                 value = value
             )
         } catch (e: SecureStorageError) {
-            Log.e(this::class.simpleName, e.message, e)
+            logger.error(this::class.simpleName.toString(), e.message.toString(), e)
         }
     }
 
@@ -34,7 +35,7 @@ class SaveToOpenSecureStoreImpl @Inject constructor(
                 value = value.toString()
             )
         } catch (e: SecureStorageError) {
-            Log.e(this::class.simpleName, e.message, e)
+            logger.error(this::class.simpleName.toString(), e.message.toString(), e)
         }
     }
 }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveToTokenSecureStoreImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveToTokenSecureStoreImpl.kt
@@ -1,14 +1,15 @@
 package uk.gov.onelogin.core.tokens.domain.save
 
-import android.util.Log
 import javax.inject.Inject
 import javax.inject.Named
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.api.Logger
 
 class SaveToTokenSecureStoreImpl @Inject constructor(
     @Named("Token")
-    private val secureStore: SecureStore
+    private val secureStore: SecureStore,
+    private val logger: Logger
 ) : SaveToTokenSecureStore {
     override suspend fun invoke(
         key: String,
@@ -20,7 +21,7 @@ class SaveToTokenSecureStoreImpl @Inject constructor(
                 value = value
             )
         } catch (e: SecureStorageError) {
-            Log.e(this::class.simpleName, e.message, e)
+            logger.error(this::class.simpleName.toString(), e.message.toString(), e)
         }
     }
 }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensImpl.kt
@@ -2,13 +2,14 @@ package uk.gov.onelogin.core.tokens.domain.save
 
 import javax.inject.Inject
 import uk.gov.onelogin.core.tokens.data.TokenRepository
-import uk.gov.onelogin.core.tokens.domain.extractPersistentIdFromIdToken
+import uk.gov.onelogin.core.tokens.domain.VerifyIdToken
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 
 class SaveTokensImpl @Inject constructor(
     private val tokenRepository: TokenRepository,
     private val saveToTokenSecureStore: SaveToTokenSecureStore,
-    private val saveToOpenSecureStore: SaveToOpenSecureStore
+    private val saveToOpenSecureStore: SaveToOpenSecureStore,
+    private val verifyIdToken: VerifyIdToken
 ) : SaveTokens {
     override suspend fun invoke() {
         val tokens = tokenRepository.getTokenResponse()
@@ -17,7 +18,7 @@ class SaveTokensImpl @Inject constructor(
                 key = AuthTokenStoreKeys.ACCESS_TOKEN_KEY,
                 value = tokenResponse.accessToken
             )
-            tokenResponse.idToken.extractPersistentIdFromIdToken()
+            verifyIdToken.extractPersistentIdFromIdToken(tokenResponse.idToken)
                 ?.let { id ->
                     saveToOpenSecureStore.save(
                         key = AuthTokenStoreKeys.PERSISTENT_ID_KEY,

--- a/core/src/test/java/uk/gov/onelogin/core/network/domain/StsAuthenticationProviderTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/network/domain/StsAuthenticationProviderTest.kt
@@ -13,6 +13,7 @@ import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.auth.AuthenticationResponse
 import uk.gov.android.network.client.GenericHttpClient
 import uk.gov.android.network.client.StubHttpClient
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.navigation.data.SignOutRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.core.tokens.data.TokenRepository
@@ -22,6 +23,7 @@ class StsAuthenticationProviderTest {
     private val mockTokenRepository: TokenRepository = mock()
     private val mockIsAccessTokenExpired: IsAccessTokenExpired = mock()
     private val mockNavigator: Navigator = mock()
+    private val logger = SystemLogger()
     private lateinit var stubHttpClient: GenericHttpClient
     private lateinit var provider: AuthenticationProvider
 
@@ -78,6 +80,7 @@ class StsAuthenticationProviderTest {
             val response = provider.fetchBearerToken("scope")
 
             assertThat("response is Failure", response is AuthenticationResponse.Failure)
+            assertThat("logger has a log", logger.size == 1)
         }
 
     @Test
@@ -148,7 +151,8 @@ class StsAuthenticationProviderTest {
                 mockTokenRepository,
                 mockIsAccessTokenExpired,
                 stubHttpClient,
-                mockNavigator
+                mockNavigator,
+                logger
             )
     }
 }

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/remove/RemoveAllSecureStoreDataTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/remove/RemoveAllSecureStoreDataTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.extensions.CoroutinesTestExtension
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 
@@ -20,10 +21,11 @@ import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 class RemoveAllSecureStoreDataTest {
     private lateinit var useCase: RemoveAllSecureStoreData
     private val mockSecureStore: SecureStore = mock()
+    private val logger = SystemLogger()
 
     @BeforeEach
     fun setUp() {
-        useCase = RemoveAllSecureStoreDataImpl(mockSecureStore)
+        useCase = RemoveAllSecureStoreDataImpl(mockSecureStore, logger)
     }
 
     @Test
@@ -38,6 +40,7 @@ class RemoveAllSecureStoreDataTest {
                 AuthTokenStoreKeys.ID_TOKEN_KEY
             )
             assertEquals(Result.success(Unit), result)
+            assertEquals(0, logger.size)
         }
 
     @Test
@@ -53,5 +56,6 @@ class RemoveAllSecureStoreDataTest {
             assertTrue(result.isFailure)
             assertTrue(result.exceptionOrNull() is SecureStorageError)
             assertTrue(result.exceptionOrNull()?.message!!.contains("something went wrong"))
+            assertTrue(logger.contains("java.lang.Exception: something went wrong"))
         }
 }

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetEmailImplTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetEmailImplTest.kt
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.onelogin.core.tokens.data.TokenRepository
+import uk.gov.onelogin.core.tokens.domain.VerifyIdToken
 
 class GetEmailImplTest {
     private val expectedEmail = "email@mail.com"
@@ -20,8 +22,9 @@ class GetEmailImplTest {
             "ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo"
     private val tokenResponse: TokenResponse = mock()
     private val tokenRepository: TokenRepository = mock()
+    private val verifyIdToken: VerifyIdToken = mock()
 
-    val sut = GetEmailImpl(tokenRepository)
+    val sut = GetEmailImpl(tokenRepository, verifyIdToken)
 
     @BeforeEach
     fun setUp() {
@@ -34,6 +37,7 @@ class GetEmailImplTest {
         // Given id token contains email
         whenever(tokenResponse.idToken).thenReturn(idTokenWithEmail)
         whenever(tokenRepository.getTokenResponse()).thenReturn(tokenResponse)
+        whenever(verifyIdToken.extractEmailFromIdToken(any())).thenReturn(expectedEmail)
 
         val emailResponse = sut.invoke()
         assertEquals(expectedEmail, emailResponse)

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromEncryptedSecureStoreTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetFromEncryptedSecureStoreTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyVararg
@@ -14,6 +15,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.RetrievalEvent
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStoreErrorType
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.FragmentActivityTestCase
 import uk.gov.onelogin.core.tokens.data.LocalAuthStatus
 
@@ -21,12 +23,13 @@ import uk.gov.onelogin.core.tokens.data.LocalAuthStatus
 class GetFromEncryptedSecureStoreTest : FragmentActivityTestCase() {
     private lateinit var useCase: GetFromEncryptedSecureStore
     private val mockSecureStore: SecureStore = mock()
+    private val logger = SystemLogger()
 
     private val expectedStoreKey: String = "key"
 
     @Before
     fun setUp() {
-        useCase = GetFromEncryptedSecureStoreImpl(mockSecureStore)
+        useCase = GetFromEncryptedSecureStoreImpl(mockSecureStore, logger)
     }
 
     @Test
@@ -40,6 +43,13 @@ class GetFromEncryptedSecureStoreTest : FragmentActivityTestCase() {
             ) {
                 assertEquals(LocalAuthStatus.SecureStoreError, it)
             }
+
+            assertTrue(
+                logger.contains(
+                    "Secure store retrieval failed: " +
+                        "\ntype - GENERAL\nreason - null"
+                )
+            )
         }
 
     @Test
@@ -53,6 +63,13 @@ class GetFromEncryptedSecureStoreTest : FragmentActivityTestCase() {
             ) {
                 assertEquals(LocalAuthStatus.UserCancelled, it)
             }
+
+            assertTrue(
+                logger.contains(
+                    "Secure store retrieval failed: " +
+                        "\ntype - USER_CANCELED_BIO_PROMPT\nreason - null"
+                )
+            )
         }
 
     @Test
@@ -65,6 +82,13 @@ class GetFromEncryptedSecureStoreTest : FragmentActivityTestCase() {
             ) {
                 assertEquals(LocalAuthStatus.BioCheckFailed, it)
             }
+
+            assertTrue(
+                logger.contains(
+                    "Secure store retrieval failed: " +
+                        "\ntype - FAILED_BIO_PROMPT\nreason - null"
+                )
+            )
         }
 
     @Test
@@ -82,6 +106,8 @@ class GetFromEncryptedSecureStoreTest : FragmentActivityTestCase() {
             ) {
                 assertEquals(LocalAuthStatus.Success(expectedResult), it)
             }
+
+            assertEquals(0, logger.size)
         }
 
     private suspend fun mockSecureStore(returnResult: RetrievalEvent) {

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveToOpenSecureStoreTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveToOpenSecureStoreTest.kt
@@ -1,8 +1,10 @@
 package uk.gov.onelogin.core.tokens.domain.save
 
 import io.ktor.util.date.getTimeMillis
+import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -13,6 +15,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.extensions.CoroutinesTestExtension
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -20,6 +23,7 @@ import uk.gov.onelogin.core.extensions.CoroutinesTestExtension
 class SaveToOpenSecureStoreTest {
     private lateinit var useCase: SaveToOpenSecureStore
     private val mockSecureStore: SecureStore = mock()
+    private val logger = SystemLogger()
 
     private val expectedStoreKey: String = "key"
     private val expectedStoreValueString: String = "value"
@@ -27,7 +31,7 @@ class SaveToOpenSecureStoreTest {
 
     @BeforeEach
     fun setUp() {
-        useCase = SaveToOpenSecureStoreImpl(mockSecureStore)
+        useCase = SaveToOpenSecureStoreImpl(mockSecureStore, logger)
     }
 
     @Test
@@ -40,6 +44,8 @@ class SaveToOpenSecureStoreTest {
             assertDoesNotThrow {
                 useCase.save(expectedStoreKey, expectedStoreValueString)
             }
+
+            assertTrue(logger.contains("java.lang.Exception: Some error"))
         }
 
     @Test
@@ -51,6 +57,8 @@ class SaveToOpenSecureStoreTest {
                 expectedStoreKey,
                 expectedStoreValueString
             )
+
+            assertEquals(0, logger.size)
         }
 
     @Test
@@ -62,5 +70,7 @@ class SaveToOpenSecureStoreTest {
                 expectedStoreKey,
                 expectedStoreValueNumber.toString()
             )
+
+            assertEquals(0, logger.size)
         }
 }

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveToTokenSecureStoreTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveToTokenSecureStoreTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.onelogin.core.tokens.domain.save
 
+import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -12,19 +14,21 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.SecureStore
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.logging.testdouble.SystemLogger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(uk.gov.onelogin.core.extensions.CoroutinesTestExtension::class)
 class SaveToTokenSecureStoreTest {
     private lateinit var useCase: SaveToTokenSecureStore
     private val mockSecureStore: SecureStore = mock()
+    private val logger = SystemLogger()
 
     private val expectedStoreKey: String = "key"
     private val expectedStoreValue: String = "value"
 
     @BeforeEach
     fun setUp() {
-        useCase = SaveToTokenSecureStoreImpl(mockSecureStore)
+        useCase = SaveToTokenSecureStoreImpl(mockSecureStore, logger)
     }
 
     @Test
@@ -37,6 +41,8 @@ class SaveToTokenSecureStoreTest {
             assertDoesNotThrow {
                 useCase.invoke(expectedStoreKey, expectedStoreValue)
             }
+
+            assertTrue(logger.contains("java.lang.Exception: Some error"))
         }
 
     @Test
@@ -48,5 +54,7 @@ class SaveToTokenSecureStoreTest {
                 expectedStoreKey,
                 expectedStoreValue
             )
+
+            assertEquals(0, logger.size)
         }
 }

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -11,6 +12,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.onelogin.core.tokens.data.TokenRepository
+import uk.gov.onelogin.core.tokens.domain.VerifyIdToken
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 
 class SaveTokensTest {
@@ -18,6 +20,7 @@ class SaveTokensTest {
     private val mockTokenRepository: TokenRepository = mock()
     private val mockSaveToTokenSecureStore: SaveToTokenSecureStore = mock()
     private val mockSaveToOpenSecureStore: SaveToOpenSecureStore = mock()
+    private val mockVerifyIdToken: VerifyIdToken = Mockito.mock()
 
     // encoded ID token with persistent ID in the body
     private val idToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwZXJzaXN0ZW50X2lkIjoiMTIzNCJ9"
@@ -28,7 +31,8 @@ class SaveTokensTest {
             SaveTokensImpl(
                 mockTokenRepository,
                 mockSaveToTokenSecureStore,
-                mockSaveToOpenSecureStore
+                mockSaveToOpenSecureStore,
+                mockVerifyIdToken
             )
     }
 
@@ -44,6 +48,7 @@ class SaveTokensTest {
                 )
 
             whenever(mockTokenRepository.getTokenResponse()).thenReturn(testResponse)
+            whenever(mockVerifyIdToken.extractPersistentIdFromIdToken(idToken)).thenReturn("1234")
 
             saveTokens()
 
@@ -86,10 +91,7 @@ class SaveTokensTest {
                     AuthTokenStoreKeys.ID_TOKEN_KEY,
                     "id"
                 )
-                verify(mockSaveToOpenSecureStore, times(0)).save(
-                    AuthTokenStoreKeys.PERSISTENT_ID_KEY,
-                    "1234"
-                )
+                verifyNoInteractions(mockSaveToOpenSecureStore)
             }
         }
 

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/save/SaveTokensTest.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever

--- a/features/build.gradle.kts
+++ b/features/build.gradle.kts
@@ -122,7 +122,8 @@ dependencies {
         libs.androidx.espresso.core,
         libs.androidx.navigation.testing,
         libs.androidx.test.orchestrator,
-        libs.androidx.espresso.intents
+        libs.androidx.espresso.intents,
+        libs.logging.test
     ).forEach(::testImplementation)
 
     listOf(

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoLocalSourceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoLocalSourceImpl.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.features.appinfo.data
 
 import android.content.SharedPreferences
-import android.util.Log
 import androidx.core.content.edit
 import javax.inject.Inject
 import kotlinx.serialization.SerializationException
@@ -39,7 +38,6 @@ class AppInfoLocalSourceImpl @Inject constructor(
     private fun decodeAppInfoData(result: String): AppInfoLocalState {
         return try {
             val decodedResult = Json.decodeFromString<AppInfoData>(result)
-            Log.d("AppInfoLocal", "$decodedResult")
             AppInfoLocalState.Success(decodedResult)
         } catch (e: SerializationException) {
             AppInfoLocalState.Failure(reason = APP_INFO_ILLEGAL_ARG_ERROR, exp = e)

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppVersionCheckImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppVersionCheckImpl.kt
@@ -1,7 +1,7 @@
 package uk.gov.onelogin.features.appinfo.data
 
-import android.util.Log
 import javax.inject.Inject
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.features.appinfo.AppInfoUtils
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoData
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoServiceState
@@ -11,7 +11,8 @@ import uk.gov.onelogin.features.appinfo.domain.BuildConfigVersion
 class AppVersionCheckImpl @Inject constructor(
     private val utils: AppInfoUtils,
     @BuildConfigVersion
-    private val appVersion: String
+    private val appVersion: String,
+    private val logger: Logger
 ) : AppVersionCheck {
     override fun compareVersions(data: AppInfoData): AppInfoServiceState {
         val updatedVersion = data.apps.android.minimumVersion
@@ -37,7 +38,7 @@ class AppVersionCheckImpl @Inject constructor(
                 }
             }
         } catch (e: AppInfoUtils.AppError) {
-            Log.e(TAG, e.toString())
+            logger.error(TAG, e.toString(), e)
             result = AppInfoServiceState.Unavailable
         }
         return result

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoApiImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoApiImpl.kt
@@ -1,7 +1,6 @@
 package uk.gov.onelogin.features.appinfo.domain
 
 import android.content.Context
-import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlinx.serialization.SerializationException
@@ -42,11 +41,11 @@ class AppInfoApiImpl @Inject constructor(
                 try {
                     val decodedResponse = jsonDecoder
                         .decodeFromString<AppInfoData>(response.response.toString())
-                    Log.d("AppInfoRemote", "$decodedResponse")
                     ApiResponse.Success(decodedResponse)
                 } catch (e: SerializationException) {
                     ApiResponse.Failure(1, e)
                 }
+
             else -> response
         }
     }

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
@@ -1,7 +1,7 @@
 package uk.gov.onelogin.features.appinfo.domain
 
-import android.util.Log
 import javax.inject.Inject
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoLocalState
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoRemoteState
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoServiceState
@@ -9,7 +9,8 @@ import uk.gov.onelogin.features.appinfo.data.model.AppInfoServiceState
 class AppInfoServiceImpl @Inject constructor(
     private val remoteSource: AppInfoRemoteSource,
     private val localSource: AppInfoLocalSource,
-    private val appVersionCheck: AppVersionCheck
+    private val appVersionCheck: AppVersionCheck,
+    private val logger: Logger
 ) : AppInfoService {
     override suspend fun get(): AppInfoServiceState {
         return when (val remoteResult = remoteSource.get()) {
@@ -19,7 +20,7 @@ class AppInfoServiceImpl @Inject constructor(
             }
             AppInfoRemoteState.Offline -> useLocalSource(AppInfoServiceState.Offline)
             is AppInfoRemoteState.Failure -> {
-                Log.e(TAG, remoteResult.reason)
+                logger.error(TAG, remoteResult.reason)
                 useLocalSource(AppInfoServiceState.Unavailable)
             }
         }

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreenViewModel.kt
@@ -2,7 +2,6 @@ package uk.gov.onelogin.features.login.ui.signin.welcome
 
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
@@ -18,6 +17,7 @@ import uk.gov.android.authentication.login.AuthenticationError
 import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.onelogin.core.R
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.biometrics.data.BiometricPreference
 import uk.gov.onelogin.core.biometrics.data.BiometricStatus
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
@@ -52,6 +52,7 @@ class WelcomeScreenViewModel @Inject constructor(
     private val handleRemoteLogin: HandleRemoteLogin,
     private val handleLoginRedirect: HandleLoginRedirect,
     private val signOutUseCase: SignOutUseCase,
+    private val logger: Logger,
     val onlineChecker: OnlineChecker
 ) : ViewModel() {
     private val tag = this::class.java.simpleName
@@ -85,7 +86,9 @@ class WelcomeScreenViewModel @Inject constructor(
                     }
                 },
                 onFailure = {
-                    Log.e(tag, it?.message, it)
+                    it?.let {
+                        logger.error(tag, it.message.toString(), it)
+                    }
                     handleLoginErrors(it, fragmentActivity)
                 }
             )

--- a/features/src/main/java/uk/gov/onelogin/features/navigation/domain/NavigatorImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/navigation/domain/NavigatorImpl.kt
@@ -1,17 +1,24 @@
 package uk.gov.onelogin.features.navigation.domain
 
-import android.util.Log
 import androidx.navigation.NavHostController
 import javax.inject.Inject
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.navigation.domain.NavRoute
 import uk.gov.onelogin.core.navigation.domain.Navigator
 import uk.gov.onelogin.core.navigation.domain.hasPreviousBackStack
 import uk.gov.onelogin.developer.DeveloperRoutes.navigateToDeveloperPanel
 
-class NavigatorImpl @Inject constructor() : Navigator {
+class NavigatorImpl @Inject constructor(
+    private val logger: Logger
+) : Navigator {
     private var navController: NavHostController? = null
         get() {
-            if (field == null) Log.w(this::class.simpleName, "Navigator not initialised")
+            if (field == null) {
+                logger.error(
+                    this::class.java.simpleName,
+                    "Navigator not initialised"
+                )
+            }
             return field
         }
 
@@ -23,7 +30,7 @@ class NavigatorImpl @Inject constructor() : Navigator {
         route: NavRoute,
         popUpToInclusive: Boolean
     ) {
-        Log.d("Navigator", "Navigating to: ${route.getRoute()}")
+        logger.debug("Navigator", "Navigating to: ${route.getRoute()}")
         navController?.let { controller ->
             if (popUpToInclusive) {
                 controller.navigate(route.getRoute()) {

--- a/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/domain/SignOutUseCaseImpl.kt
@@ -21,4 +21,4 @@ class SignOutUseCaseImpl @Inject constructor(
     }
 }
 
-data class SignOutError(val error: Throwable) : Error()
+data class SignOutError(val error: Throwable) : Error(error)

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignOutViewModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.onelogin.features.signout.ui
 
-import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import uk.gov.android.featureflags.FeatureFlags
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.navigation.data.ErrorRoutes
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
@@ -22,7 +22,8 @@ import uk.gov.onelogin.features.signout.domain.SignOutUseCase
 class SignOutViewModel @Inject constructor(
     private val navigator: Navigator,
     private val signOutUseCase: SignOutUseCase,
-    private val featureFlags: FeatureFlags
+    private val featureFlags: FeatureFlags,
+    private val logger: Logger
 ) : ViewModel() {
     private val _loadingState = MutableStateFlow(false)
     val loadingState = _loadingState.asStateFlow()
@@ -41,7 +42,7 @@ class SignOutViewModel @Inject constructor(
                 signOutUseCase.invoke(activityFragment)
                 navigator.navigate(LoginRoutes.Root, true)
             } catch (e: SignOutError) {
-                Log.e(this::class.simpleName, e.message, e)
+                logger.error(SignOutViewModel::class.java.simpleName, e.message.toString(), e)
                 navigator.navigate(ErrorRoutes.SignOut, true)
             }
         }

--- a/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModel.kt
@@ -1,12 +1,12 @@
 package uk.gov.onelogin.features.signout.ui
 
-import android.util.Log
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import uk.gov.logging.api.Logger
 import uk.gov.onelogin.core.biometrics.domain.BioPreferencesUseCase
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.data.SignOutRoutes
@@ -17,6 +17,7 @@ import uk.gov.onelogin.core.tokens.domain.save.SaveTokens
 import uk.gov.onelogin.features.signout.domain.SignOutError
 import uk.gov.onelogin.features.signout.domain.SignOutUseCase
 
+@Suppress("LongParameterList")
 @HiltViewModel
 class SignedOutInfoViewModel @Inject constructor(
     private val navigator: Navigator,
@@ -24,7 +25,8 @@ class SignedOutInfoViewModel @Inject constructor(
     private val saveTokens: SaveTokens,
     private val getPersistentId: GetPersistentId,
     private val signOutUseCase: SignOutUseCase,
-    private val bioPreferencesUseCase: BioPreferencesUseCase
+    private val bioPreferencesUseCase: BioPreferencesUseCase,
+    private val logger: Logger
 ) : ViewModel() {
     fun resetTokens() {
         tokenRepository.clearTokenResponse()
@@ -48,7 +50,11 @@ class SignedOutInfoViewModel @Inject constructor(
                     signOutUseCase.invoke(activity)
                     navigator.navigate(SignOutRoutes.ReAuthError, true)
                 } catch (error: SignOutError) {
-                    Log.e(this::class.simpleName, error.message, error)
+                    logger.error(
+                        this@SignedOutInfoViewModel::class.java.simpleName,
+                        error.message.toString(),
+                        error
+                    )
                     navigator.navigate(LoginRoutes.SignInError, true)
                 }
             } else {

--- a/features/src/test/java/uk/gov/onelogin/features/appinfo/data/AppInfoServiceImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/appinfo/data/AppInfoServiceImplTest.kt
@@ -2,10 +2,12 @@ package uk.gov.onelogin.features.appinfo.data
 
 import kotlin.test.assertEquals
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.features.TestUtils
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoLocalState
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoRemoteState
@@ -19,6 +21,7 @@ class AppInfoServiceImplTest {
     private val remoteSource: AppInfoRemoteSource = mock()
     private val localSource: AppInfoLocalSource = mock()
     private val appVersionCheck: AppVersionCheck = mock()
+    private val logger = SystemLogger()
     private val data = TestUtils.appInfoData
     private val dataAppUnavailable = TestUtils.appInfoDataAppUnavailable
     private val localSourceErrorMsg = AppInfoLocalSourceImpl.APP_INFO_LOCAL_SOURCE_ERROR
@@ -28,7 +31,8 @@ class AppInfoServiceImplTest {
         AppInfoServiceImpl(
             remoteSource,
             localSource,
-            appVersionCheck
+            appVersionCheck,
+            logger
         )
 
     @Test
@@ -40,6 +44,7 @@ class AppInfoServiceImplTest {
                 .thenReturn(AppInfoServiceState.Successful(data))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Successful(data), result)
+            assertTrue(logger.size == 0)
         }
 
     @Test
@@ -51,6 +56,7 @@ class AppInfoServiceImplTest {
                 .thenReturn(AppInfoServiceState.Successful(data))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Successful(data), result)
+            assertTrue(logger.size == 0)
         }
 
     @Test
@@ -60,6 +66,7 @@ class AppInfoServiceImplTest {
             whenever(localSource.get()).thenReturn(AppInfoLocalState.Failure("Error"))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Offline, result)
+            assertTrue(logger.size == 0)
         }
 
     @Test
@@ -73,6 +80,7 @@ class AppInfoServiceImplTest {
                 .thenReturn(AppInfoServiceState.Successful(data))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Successful(data), result)
+            assertTrue(logger.contains(remoteSourceErrorMsg))
         }
 
     @Test
@@ -84,6 +92,7 @@ class AppInfoServiceImplTest {
             whenever(localSource.get()).thenReturn(AppInfoLocalState.Failure(localSourceErrorMsg))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Unavailable, result)
+            assertTrue(logger.contains(remoteSourceErrorMsg))
         }
 
     @Test
@@ -95,6 +104,7 @@ class AppInfoServiceImplTest {
                 .thenReturn(AppInfoServiceState.UpdateRequired)
             val result = sut.get()
             assertEquals(AppInfoServiceState.UpdateRequired, result)
+            assertTrue(logger.size == 0)
         }
 
     @Test
@@ -104,5 +114,6 @@ class AppInfoServiceImplTest {
             whenever(localSource.get()).thenReturn(AppInfoLocalState.Success(dataAppUnavailable))
             val result = sut.get()
             assertEquals(AppInfoServiceState.Unavailable, result)
+            assertTrue(logger.size == 0)
         }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/appinfo/data/AppVersionCheckImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/appinfo/data/AppVersionCheckImplTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.onelogin.features.appinfo.data
 
-import junit.framework.TestCase.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.features.TestUtils
 import uk.gov.onelogin.features.appinfo.AppInfoUtils
 import uk.gov.onelogin.features.appinfo.AppInfoUtilsImpl
@@ -9,7 +11,8 @@ import uk.gov.onelogin.features.appinfo.data.model.AppInfoServiceState
 
 class AppVersionCheckImplTest {
     private val appInfoUtils: AppInfoUtils = AppInfoUtilsImpl()
-    private val sut = AppVersionCheckImpl(appInfoUtils, "1.0.0")
+    private val logger = SystemLogger()
+    private val sut = AppVersionCheckImpl(appInfoUtils, "1.0.0", logger)
 
     @Test
     fun versionCheckSuccessful() {
@@ -17,17 +20,20 @@ class AppVersionCheckImplTest {
         assertEquals(AppInfoServiceState.Successful(TestUtils.appInfoData), result)
         result = sut.compareVersions(TestUtils.additionalAppInfoData)
         assertEquals(AppInfoServiceState.Successful(TestUtils.additionalAppInfoData), result)
+        assertTrue(logger.size == 0)
     }
 
     @Test
     fun versionCheckUpdateRequired() {
         val result = sut.compareVersions(TestUtils.updateRequiredAppInfoData)
         assertEquals(AppInfoServiceState.UpdateRequired, result)
+        assertTrue(logger.size == 0)
     }
 
     @Test
     fun versionCheckError() {
         val result = sut.compareVersions(TestUtils.extractVersionErrorAppInfoData)
         assertEquals(AppInfoServiceState.Unavailable, result)
+        assertTrue(logger.contains("IllegalVersionFormat"))
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
@@ -20,6 +20,7 @@ import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
 import uk.gov.onelogin.core.biometrics.domain.CredentialChecker
 import uk.gov.onelogin.core.navigation.data.ErrorRoutes
@@ -57,6 +58,7 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
     private lateinit var analytics: AnalyticsLogger
     private lateinit var analyticsViewModel: SignInAnalyticsViewModel
     private lateinit var loadingAnalyticsVM: LoadingScreenAnalyticsViewModel
+    private val logger = SystemLogger()
 
     private var shouldTryAgainCalled = false
 
@@ -95,6 +97,7 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
                 handleRemoteLogin,
                 handleLoginRedirect,
                 signOutUseCase,
+                logger,
                 onlineChecker
             )
         analytics = mock()

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -22,6 +23,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.android.authentication.login.AuthenticationError
 import uk.gov.android.authentication.login.TokenResponse
 import uk.gov.android.network.online.OnlineChecker
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.data.BiometricPreference
 import uk.gov.onelogin.core.biometrics.data.BiometricStatus
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
@@ -61,6 +63,7 @@ class WelcomeScreenViewModelTest {
     private val mockHandleRemoteLogin: HandleRemoteLogin = mock()
     private val mockHandleLoginRedirect: HandleLoginRedirect = mock()
     private val mockSignOutUseCase: SignOutUseCase = mock()
+    private val logger = SystemLogger()
 
     private val testAccessToken = "testAccessToken"
     private var testIdToken: String = "testIdToken"
@@ -95,6 +98,7 @@ class WelcomeScreenViewModelTest {
             mockHandleRemoteLogin,
             mockHandleLoginRedirect,
             mockSignOutUseCase,
+            logger,
             mockOnlineChecker
         )
 
@@ -325,6 +329,7 @@ class WelcomeScreenViewModelTest {
 
             verify(mockSignOutUseCase).invoke(mockFragmentActivity)
             verify(mockNavigator).navigate(SignOutRoutes.ReAuthError)
+            assertThat("logger has log", logger.contains("access_denied"))
         }
 
     @Test
@@ -351,6 +356,7 @@ class WelcomeScreenViewModelTest {
 
             verifyNoInteractions(mockSignOutUseCase)
             verify(mockNavigator).navigate(LoginRoutes.SignInError, true)
+            assertThat("logger has log", logger.contains("oauth_error"))
         }
 
     @Test
@@ -393,6 +399,32 @@ class WelcomeScreenViewModelTest {
             verifyNoInteractions(mockTokenRepository)
             verifyNoInteractions(mockBioPrefHandler)
             verify(mockNavigator).navigate(LoginRoutes.SignInError, true)
+            assertThat("logger has log", logger.size == 1)
+        }
+
+    @Test
+    fun `When login redirect fails, null throwable - it displays sign in error screen`() =
+        runTest {
+            val mockIntent: Intent = mock()
+            val mockUri: Uri = mock()
+
+            whenever(mockIntent.data).thenReturn(mockUri)
+            whenever(mockHandleLoginRedirect.handle(eq(mockIntent), any(), any()))
+                .thenAnswer {
+                    (it.arguments[1] as (error: Throwable?) -> Unit).invoke(null)
+                }
+
+            viewModel.handleActivityResult(
+                mockIntent,
+                fragmentActivity = mockFragmentActivity
+            )
+
+            verifyNoInteractions(mockSaveTokens)
+            verifyNoInteractions(mockSaveTokenExpiry)
+            verifyNoInteractions(mockTokenRepository)
+            verifyNoInteractions(mockBioPrefHandler)
+            verify(mockNavigator).navigate(LoginRoutes.SignInError, true)
+            assertThat("logger has no log", logger.size == 0)
         }
 
     @Test

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenViewModelTest.kt
@@ -401,10 +401,7 @@ class WelcomeScreenViewModelTest {
                     (it.arguments[1] as (error: Throwable?) -> Unit).invoke(null)
                 }
 
-            viewModel.handleActivityResult(
-                mockIntent,
-                fragmentActivity = mockFragmentActivity
-            )
+            viewModel.handleActivityResult(mockIntent)
 
             verifyNoInteractions(mockSaveTokens)
             verifyNoInteractions(mockSaveTokenExpiry)

--- a/features/src/test/java/uk/gov/onelogin/features/navigation/domain/NavigatorImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/navigation/domain/NavigatorImplTest.kt
@@ -2,6 +2,7 @@ package uk.gov.onelogin.features.navigation.domain
 
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -12,16 +13,18 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.navigation.domain.NavRoute
 import uk.gov.onelogin.core.navigation.domain.Navigator
 
 class NavigatorImplTest {
     private val mockNavController: NavHostController = mock()
+    private val logger = SystemLogger()
     private lateinit var navigator: Navigator
 
     @BeforeEach
     fun setup() {
-        navigator = NavigatorImpl()
+        navigator = NavigatorImpl(logger)
     }
 
     @Test
@@ -40,6 +43,7 @@ class NavigatorImplTest {
         navigator.navigate({ "test" }, true)
 
         verify(mockNavController).navigate(route = eq("test"), builder = any())
+        assertTrue(logger.contains("Navigating to: test"))
     }
 
     @Test
@@ -47,6 +51,7 @@ class NavigatorImplTest {
         navigator.navigate({ "test" })
 
         verifyNoInteractions(mockNavController)
+        assertTrue(logger.contains("Navigator not initialised"))
     }
 
     @Test
@@ -60,6 +65,7 @@ class NavigatorImplTest {
 
         verify(mockNavController, times(1))
             .navigate("test")
+        assertTrue(logger.contains("Navigating to: test"))
     }
 
     @Test

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignOutScreenTest.kt
@@ -22,6 +22,7 @@ import uk.gov.android.featureflags.InMemoryFeatureFlags
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.navigation.data.ErrorRoutes
 import uk.gov.onelogin.core.navigation.data.LoginRoutes
 import uk.gov.onelogin.core.navigation.domain.Navigator
@@ -45,6 +46,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
     private lateinit var title: SemanticsMatcher
     private lateinit var button: SemanticsMatcher
     private lateinit var closeButton: SemanticsMatcher
+    private val logger = SystemLogger()
 
     @Before
     fun setup() {
@@ -63,7 +65,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(WalletFeatureFlag.ENABLED, CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
@@ -80,7 +82,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
@@ -97,7 +99,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(WalletFeatureFlag.ENABLED, CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
@@ -114,7 +116,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(WalletFeatureFlag.ENABLED, CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
@@ -130,7 +132,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(WalletFeatureFlag.ENABLED, CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }
@@ -145,7 +147,7 @@ class SignOutScreenTest : FragmentActivityTestCase() {
         featureFlags = InMemoryFeatureFlags(
             setOf(WalletFeatureFlag.ENABLED, CriOrchestratorFeatureFlag.ENABLED)
         )
-        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags)
+        viewModel = SignOutViewModel(navigator, signOutUseCase, featureFlags, logger)
         composeTestRule.setContent {
             SignOutScreen(viewModel, analyticsViewModel, loadingAnalyticsVM)
         }

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoScreenTest.kt
@@ -25,6 +25,7 @@ import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.domain.BioPreferencesUseCase
 import uk.gov.onelogin.core.biometrics.domain.BioPreferencesUseCaseImpl
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
@@ -66,6 +67,7 @@ class SignedOutInfoScreenTest : FragmentActivityTestCase() {
     private lateinit var analyticsViewModel: SignedOutInfoAnalyticsViewModel
     private lateinit var loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel
     private lateinit var bioPreferencesUseCase: BioPreferencesUseCase
+    private val logger = SystemLogger()
     private var shouldTryAgainCalled = false
 
     private val signedOutTitle = hasText(resources.getString(R.string.app_youveBeenSignedOutTitle))
@@ -105,6 +107,7 @@ class SignedOutInfoScreenTest : FragmentActivityTestCase() {
             handleRemoteLogin,
             handleLoginRedirect,
             signOutUseCase,
+            logger,
             onlineChecker
         )
         getPersistentId = mock()
@@ -115,7 +118,8 @@ class SignedOutInfoScreenTest : FragmentActivityTestCase() {
             saveTokens,
             getPersistentId,
             signOutUseCase,
-            bioPreferencesUseCase
+            bioPreferencesUseCase,
+            logger
         )
         analytics = mock()
         analyticsViewModel = SignedOutInfoAnalyticsViewModel(context, analytics)

--- a/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/signout/ui/SignedOutInfoViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.domain.BioPreferencesUseCase
 import uk.gov.onelogin.core.biometrics.domain.BioPreferencesUseCaseImpl
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
@@ -37,6 +38,7 @@ class SignedOutInfoViewModelTest {
     private val signOutUseCase: SignOutUseCase = mock()
     private val biometricPreferenceHandler: BiometricPreferenceHandler = mock()
     private val credentialChecker: CredentialChecker = mock()
+    private val logger = SystemLogger()
     private val bioPreferencesUseCase: BioPreferencesUseCase = BioPreferencesUseCaseImpl(
         biometricPreferenceHandler,
         credentialChecker
@@ -49,7 +51,8 @@ class SignedOutInfoViewModelTest {
             saveTokens,
             getPersistentId,
             signOutUseCase,
-            bioPreferencesUseCase
+            bioPreferencesUseCase,
+            logger
         )
     }
 
@@ -144,12 +147,13 @@ class SignedOutInfoViewModelTest {
             var callback = false
             val activity: FragmentActivity = mock()
             whenever(getPersistentId.invoke()).thenReturn("")
-            whenever(signOutUseCase.invoke(any())).thenThrow(SignOutError(Error()))
+            whenever(signOutUseCase.invoke(any())).thenThrow(SignOutError(Error("test")))
 
             viewModel.checkPersistentId(activity) { callback = true }
 
             verify(signOutUseCase).invoke(activity)
             verify(navigator).navigate(LoginRoutes.SignInError, true)
             assertFalse(callback)
+            assertTrue(logger.contains("java.lang.Error: test"))
         }
 }

--- a/features/src/testBuild/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenDevMenuTest.kt
+++ b/features/src/testBuild/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenDevMenuTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.verify
 import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
 import uk.gov.onelogin.core.biometrics.domain.CredentialChecker
 import uk.gov.onelogin.core.navigation.domain.Navigator
@@ -46,6 +47,7 @@ class WelcomeScreenDevMenuTest : FragmentActivityTestCase() {
     private lateinit var analytics: AnalyticsLogger
     private lateinit var analyticsViewModel: SignInAnalyticsViewModel
     private lateinit var loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel
+    private val logger = SystemLogger()
 
     private val signInIcon =
         hasContentDescription(resources.getString(R.string.app_signInIconDescription))
@@ -78,6 +80,7 @@ class WelcomeScreenDevMenuTest : FragmentActivityTestCase() {
                 handleRemoteLogin,
                 handleLoginRedirect,
                 signOutUseCase,
+                logger,
                 onlineChecker
             )
         analytics = mock()

--- a/features/src/testProduction/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenDevMenuTest.kt
+++ b/features/src/testProduction/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenDevMenuTest.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.mock
 import uk.gov.android.network.online.OnlineChecker
 import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.testdouble.SystemLogger
 import uk.gov.onelogin.core.biometrics.domain.BiometricPreferenceHandler
 import uk.gov.onelogin.core.biometrics.domain.CredentialChecker
 import uk.gov.onelogin.core.navigation.domain.Navigator
@@ -46,6 +47,7 @@ class WelcomeScreenDevMenuTest : FragmentActivityTestCase() {
     private lateinit var analytics: AnalyticsLogger
     private lateinit var analyticsViewModel: SignInAnalyticsViewModel
     private lateinit var loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel
+    private val logger = SystemLogger()
 
     private val signInIcon =
         hasContentDescription(resources.getString(R.string.app_signInIconDescription))
@@ -78,6 +80,7 @@ class WelcomeScreenDevMenuTest : FragmentActivityTestCase() {
                 handleRemoteLogin,
                 handleLoginRedirect,
                 signOutUseCase,
+                logger,
                 onlineChecker
             )
         analytics = mock()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,7 +116,8 @@ theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
 authentication = { group = "uk.gov.android.authentication", name = "app", version = "0.17.0" }
 secure-store = { group = "uk.gov.securestore", name = "app", version = "0.8.0" }
 network = { group = "uk.gov.android", name = "network", version = "0.3.4" }
-logging = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
+logging-impl = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
+logging-test = { group = "uk.gov.logging", name = "logging-testdouble", version.ref = "govuk-logging" }
 
 # Firebase
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
@@ -134,5 +135,5 @@ aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3",
 
 [bundles]
 firebase = ["firebase-appcheck", "firebase-appcheck-debug", "firebase-analytics", "firebase-crashlytics"]
-gov-uk = ["components", "pages", "componentsv2", "patterns", "theme", "authentication", "secure-store", "network", "logging", "cri-orchestrator"]
+gov-uk = ["components", "pages", "componentsv2", "patterns", "theme", "authentication", "secure-store", "network", "logging-impl", "cri-orchestrator"]
 about-libraries = [ "aboutlibraries-core", "aboutlibraries-compose-core", "aboutlibraries-compose-m3" ]


### PR DESCRIPTION
### [DCMAW-7903](https://govukverify.atlassian.net/browse/DCMAW-7903)

### Description of Changes

- Logging has been added to any Secure Store failure scenarios. I chose to add this in the one-login codebase rather than dictate that the secure store itself would require a `Logger`
- Also removed all instances of `android.util.Log` across the codebase and replaces with our own `Logger`. This improves testability and maintainability

[DCMAW-7903]: https://govukverify.atlassian.net/browse/DCMAW-7903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ