### PR TITLE
fix: DCMAW-10244 update content description of welcome screen icon

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="app_unlockButton">Unlock</string>
     <string name="app_signInErrorTitle">There was a problem signing you in</string>
     <string name="app_signInErrorBody">You can try signing in again.\n\nIf this does not work, you may need to try again later.</string>
-    <string name="app_signInIconDescription" translatable="false">Gov Uk Icon</string>
+    <string name="app_signInIconDescription" translatable="false">GOV.UK Icon</string>
 
     <!-- Errors -->
     <!-- App Unavailable -->


### PR DESCRIPTION
## [DCMAW-10244]()

### Description of changes

- As can be seen in the evidence, the bug referenced in the ticket is not present anymore (maybe inadvertently fixed) however the read-out for the icon on the sign in screen was noticed to be wrong.

### Evidence
