### PR TITLE
chore(deps): enable GOV.UK One Login packages to be updated by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  github-maven:
+    type: maven-repository
+    url: https://maven.pkg.github.com/govuk-one-login/*
+    username: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
+    password: ${{ secrets.MODULE_FETCH_TOKEN }}
 updates:
   - package-ecosystem: github-actions
     directories:


### PR DESCRIPTION
Provide Dependabot with details of the GOV.UK One Login GitHub Maven repository and authentication details so that it can be used to update internal dependencies.