### PR TITLE
feat: move error screens onto M3 `ErrorScreen`

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/SignOutErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/SignOutErrorScreen.kt
@@ -1,17 +1,13 @@
 package uk.gov.onelogin.features.error.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.onelogin.core.R
-import uk.gov.android.ui.components.HeadingSize
-import uk.gov.android.ui.components.buttons.ButtonParameters
-import uk.gov.android.ui.components.buttons.ButtonType
-import uk.gov.android.ui.components.content.ContentParameters
-import uk.gov.android.ui.components.content.GdsContentText
-import uk.gov.android.ui.components.images.icon.IconParameters
-import uk.gov.android.ui.components.information.InformationParameters
-import uk.gov.android.ui.pages.errors.ErrorPage
-import uk.gov.android.ui.pages.errors.ErrorPageParameters
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenBodyContent
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenButton
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreen
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreenIcon
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.meta.ExcludeFromJacocoGeneratedReport
 import uk.gov.android.ui.theme.meta.ScreenPreview
@@ -21,31 +17,18 @@ import uk.gov.onelogin.core.ui.pages.EdgeToEdgePage
 fun SignOutErrorScreen(onExitAppClicked: () -> Unit) {
     GdsTheme {
         EdgeToEdgePage { _ ->
-            ErrorPage(
-                parameters = ErrorPageParameters(
-                    primaryButtonParameters = ButtonParameters(
-                        buttonType = ButtonType.PRIMARY(),
-                        onClick = onExitAppClicked,
-                        text = R.string.app_exitButton
-                    ),
-                    informationParameters = InformationParameters(
-                        contentParameters = ContentParameters(
-                            resource = listOf(
-                                GdsContentText.GdsContentTextString(
-                                    subTitle = R.string.app_signOutErrorTitle,
-                                    text =
-                                    intArrayOf(
-                                        R.string.app_signOutErrorBody
-                                    )
-                                )
-                            ),
-                            headingSize = HeadingSize.H1()
-                        ),
-                        iconParameters = IconParameters(
-                            foreGroundColor = Color.Unspecified,
-                            image = uk.gov.android.ui.components.R.drawable.ic_error
-                        )
+            ErrorScreen(
+                icon = ErrorScreenIcon.ErrorIcon,
+                title = stringResource(R.string.app_signOutErrorTitle),
+                body = persistentListOf(
+                    CentreAlignedScreenBodyContent.Text(
+                        bodyText = stringResource(R.string.app_signOutErrorBody)
                     )
+                ),
+                primaryButton =
+                CentreAlignedScreenButton(
+                    text = stringResource(R.string.app_exitButton),
+                    onClick = onExitAppClicked
                 )
             )
         }

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/signin/SignInErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/signin/SignInErrorScreen.kt
@@ -3,20 +3,18 @@ package uk.gov.onelogin.features.error.ui.signin
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.collections.immutable.persistentListOf
 import uk.gov.android.onelogin.core.R
-import uk.gov.android.ui.components.HeadingSize
-import uk.gov.android.ui.components.buttons.ButtonParameters
-import uk.gov.android.ui.components.buttons.ButtonType
-import uk.gov.android.ui.components.content.ContentParameters
-import uk.gov.android.ui.components.content.GdsContentText
-import uk.gov.android.ui.components.images.icon.IconParameters
-import uk.gov.android.ui.components.information.InformationParameters
-import uk.gov.android.ui.pages.errors.ErrorPage
-import uk.gov.android.ui.pages.errors.ErrorPageParameters
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenBodyContent
+import uk.gov.android.ui.patterns.centrealignedscreen.CentreAlignedScreenButton
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreen
+import uk.gov.android.ui.patterns.errorscreen.ErrorScreenIcon
 import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.meta.ExcludeFromJacocoGeneratedReport
+import uk.gov.android.ui.theme.meta.ScreenPreview
 import uk.gov.onelogin.core.ui.pages.EdgeToEdgePage
 
 @Composable
@@ -33,33 +31,39 @@ fun SignInErrorScreen(
         }
         LaunchedEffect(Unit) { analyticsViewModel.trackScreen() }
         EdgeToEdgePage { _ ->
-            ErrorPage(
-                parameters = ErrorPageParameters(
-                    primaryButtonParameters = ButtonParameters(
-                        buttonType = ButtonType.PRIMARY(),
-                        onClick = {
-                            analyticsViewModel.trackButton()
-                            onClick()
-                        },
-                        text = R.string.app_closeButton
-                    ),
-                    informationParameters = InformationParameters(
-                        contentParameters = ContentParameters(
-                            resource = listOf(
-                                GdsContentText.GdsContentTextString(
-                                    subTitle = R.string.app_signInErrorTitle,
-                                    text = intArrayOf(R.string.app_signInErrorBody)
-                                )
-                            ),
-                            headingSize = HeadingSize.H1()
-                        ),
-                        iconParameters = IconParameters(
-                            foreGroundColor = Color.Unspecified,
-                            image = uk.gov.android.ui.components.R.drawable.ic_error
-                        )
-                    )
-                )
-            )
+            SignInErrorBody {
+                analyticsViewModel.trackButton()
+                onClick()
+            }
         }
+    }
+}
+
+@Composable
+private fun SignInErrorBody(
+    onPrimary: () -> Unit
+) {
+    ErrorScreen(
+        icon = ErrorScreenIcon.ErrorIcon,
+        title = stringResource(R.string.app_signInErrorTitle),
+        body = persistentListOf(
+            CentreAlignedScreenBodyContent.Text(
+                bodyText = stringResource(R.string.app_signInErrorBody)
+            )
+        ),
+        primaryButton =
+        CentreAlignedScreenButton(
+            text = stringResource(R.string.app_closeButton),
+            onClick = onPrimary
+        )
+    )
+}
+
+@ExcludeFromJacocoGeneratedReport
+@ScreenPreview
+@Composable
+fun SignInErrorScreenPreview() {
+    GdsTheme {
+        SignInErrorBody {}
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/error/ui/signin/SignInErrorScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/error/ui/signin/SignInErrorScreenTest.kt
@@ -29,13 +29,13 @@ class SignInErrorScreenTest : FragmentActivityTestCase() {
     fun setupNavigation() {
         analytics = mock()
         viewModel = SignInErrorAnalyticsViewModel(context, analytics)
-        composeTestRule.setContent {
-            SignInErrorScreen(analyticsViewModel = viewModel) { onClick = !onClick }
-        }
     }
 
     @Test
     fun verifyComponents() {
+        composeTestRule.setContent {
+            SignInErrorScreen(analyticsViewModel = viewModel) { onClick = !onClick }
+        }
         composeTestRule.onNode(title).assertIsDisplayed()
         composeTestRule.onNode(body).assertIsDisplayed()
         composeTestRule.onNode(button).apply {
@@ -49,7 +49,17 @@ class SignInErrorScreenTest : FragmentActivityTestCase() {
 
     @Test
     fun checkBackClicked() {
+        composeTestRule.setContent {
+            SignInErrorScreen(analyticsViewModel = viewModel) { onClick = !onClick }
+        }
         Espresso.pressBack()
         verify(analytics).logEventV3Dot1(SignInErrorAnalyticsViewModel.makeBackEvent(context))
+    }
+
+    @Test
+    fun preview() {
+        composeTestRule.setContent {
+            SignInErrorScreenPreview()
+        }
     }
 }


### PR DESCRIPTION
### Resolves: [DCMAW-13448](https://govukverify.atlassian.net/browse/DCMAW-13448)

- Moving the last couple of Error Screens onto the `patterns.ErrorScreen`

[DCMAW-13448.webm](https://github.com/user-attachments/assets/fa9e1f61-21cb-4d6b-9846-01ecd1915946)

[DCMAW-13448]: https://govukverify.atlassian.net/browse/DCMAW-13448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ