### PR TITLE
build: Remove explicit ID Check SDK version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,11 +47,10 @@ govuk-logging = "0.25.0"
 compose-runtime = "1.8.0"
 wallet = "1.91.0"
 auth = "0.21.0"
-cri-orchestrator = "0.55.3"
+cri-orchestrator = "0.56.0"
 junitVersion = "4.13.2"
 material = "1.12.0"
 robolectric = "4.14.1"
-gov-uk-idcheck = "0.14.5"
 aboutLibraries = "12.1.0-rc01"
 
 [libraries]
@@ -111,8 +110,7 @@ roboelectric = { group = "org.robolectric", name = "robolectric", version.ref = 
 wallet-sdk = { module = "uk.gov.android:wallet_sdk", version.ref = "wallet" }
 cri-orchestrator = { group = "uk.gov.onelogin.criorchestrator.sdk", name = "sdk", version.ref = "cri-orchestrator" }
 cri-orchestrator-dev = { module = "uk.gov.onelogin.criorchestrator.features:dev-public-api", version.ref = "cri-orchestrator" }
-uk-gov-idcheck-sdk = { module = "uk.gov.onelogin.idcheck:sdk", version.ref = "gov-uk-idcheck" }
-uk-gov-idcheck-hilt-config = { module = "uk.gov.onelogin.idcheck:hilt-config", version.ref = "gov-uk-idcheck" }
+uk-gov-idcheck-hilt-config = { module = "uk.gov.onelogin.idcheck:hilt-config" }
 
 components = { group = "uk.gov.android", name = "components", version.ref = "govuk-ui" }
 pages = { group = "uk.gov.android", name = "pages", version.ref = "govuk-ui" }
@@ -141,7 +139,7 @@ aboutlibraries-compose-core = { module = "com.mikepenz:aboutlibraries-compose", 
 aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3", version.ref = "aboutLibraries" }
 
 [bundles]
-cri-orchestrator-bundle = ["uk-gov-idcheck-sdk", "uk-gov-idcheck-hilt-config", "cri-orchestrator-dev"]
+cri-orchestrator-bundle = ["uk-gov-idcheck-hilt-config", "cri-orchestrator-dev"]
 firebase = ["firebase-appcheck", "firebase-appcheck-debug", "firebase-analytics", "firebase-crashlytics"]
 gov-uk = ["components", "pages", "componentsv2", "patterns", "theme", "authentication", "secure-store", "network", "logging-impl", "cri-orchestrator", "localauth"]
 about-libraries = [ "aboutlibraries-core", "aboutlibraries-compose-core", "aboutlibraries-compose-m3" ]


### PR DESCRIPTION
## Changes

- Remove the explicit version declared for the ID Check SDK hilt config dependency
- Remove the direct dependency on ID Check SDK in favour of the transitive one provided by CRI Orchestrator

## Context

- [CRI Orchestrator 0.56.0](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/releases/tag/0.56.0)
  - https://github.com/govuk-one-login/mobile-android-cri-orchestrator/pull/380
