### PR TITLE
DCMAW-13889: Bottom navigation bar is disproportionately large

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/home/ui/HomeScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/home/ui/HomeScreen.kt
@@ -3,12 +3,11 @@ package uk.gov.onelogin.features.home.ui
 import androidx.activity.compose.BackHandler
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -51,11 +50,11 @@ fun HomeScreen(
     TitledLogoPage(R.drawable.ic_onelogin_title) { paddingValues ->
         Column(
             modifier = Modifier
-                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(top = paddingValues.calculateTopPadding())
                 .padding(horizontal = smallPadding)
                 .consumeWindowInsets(paddingValues)
                 .verticalScroll(rememberScrollState())
-                .height(IntrinsicSize.Max)
                 .windowInsetsPadding(WindowInsets.displayCutout)
         ) {
             if (viewModel.uiCardEnabled.collectAsState().value) {

--- a/features/src/main/java/uk/gov/onelogin/features/settings/ui/SettingsScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/settings/ui/SettingsScreen.kt
@@ -107,7 +107,7 @@ private fun SettingsScreenBody(
 ) {
     Column(
         modifier = Modifier
-            .padding(paddingValues)
+            .padding(top = paddingValues.calculateTopPadding())
             .consumeWindowInsets(paddingValues)
             .verticalScroll(rememberScrollState())
             .windowInsetsPadding(WindowInsets.displayCutout)


### PR DESCRIPTION
### [DCMAW-13889](https://govukverify.atlassian.net/browse/DCMAW-13889) Bottom navigation bar is disproportionately large

- Remove duplicate bottom padding from Home and Settings screens

### Evidence

[bottom_nav_bar_fix_evidence.webm](https://github.com/user-attachments/assets/2394dfc2-3d43-4092-8c83-8926bad8eee8)

[DCMAW-13889]: https://govukverify.atlassian.net/browse/DCMAW-13889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ