### PR TITLE
fix: add sdk app name

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -2,6 +2,9 @@
     <string name="app_name" translatable="false">One Login</string>
     <string name="action_settings" translatable="false">Settings</string>
 
+    <!-- Required in the ID Check SDK -->
+    <string name="appName" translatable="false">@string/app_name</string>
+
     <!-- Navigation -->
     <string name="app_continue">Continue</string>
     <string name="app_closeButton">Close</string>


### PR DESCRIPTION
# DCMAW-12794

- Add the `appName` required in ID Check SDK

https://github.com/govuk-one-login/mobile-id-check-android-sdk/blob/66304bec3709662400251e684b1f008626ebbd15/modules/idcheck/network-api/src/main/res/values/strings.xml

The plan is to name space the id check sdk strings so this will change to `idsdk_app_name` in the future