### PR TITLE
fix: Bump version for secure-store that fixes the API29 localauth loop

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -119,7 +119,7 @@ patterns = { group = "uk.gov.android", name = "patterns", version.ref = "govuk-u
 theme = { group = "uk.gov.android", name = "theme", version.ref = "govuk-ui" }
 authentication = { group = "uk.gov.android.authentication", name = "app", version.ref = "auth" }
 localauth = { group = "uk.gov.android.authentication", name = "localauth", version.ref = "auth" }
-secure-store = { group = "uk.gov.securestore", name = "app", version = "0.12.0" }
+secure-store = { group = "uk.gov.securestore", name = "app", version = "0.12.1" }
 network = { group = "uk.gov.android", name = "network", version = "0.3.4" }
 logging-impl = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
 logging-test = { group = "uk.gov.logging", name = "logging-testdouble", version.ref = "govuk-logging" }


### PR DESCRIPTION
- this fix will allow a user to use fingerprint only - passcodes are not supported (this will be implemented with a further change to how we handle that)
Resolves: DCMAW-13750