### PR TITLE
fix: Catch generic errors on FirebaseAppCheck

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/login/appintegrity/FirebaseAppCheck.kt
+++ b/app/src/main/java/uk/gov/onelogin/login/appintegrity/FirebaseAppCheck.kt
@@ -24,12 +24,15 @@ class FirebaseAppCheck @Inject constructor(
         Firebase.initialize(context)
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun getAppCheckToken(): Result<AppCheckToken> {
         return try {
             Result.success(
                 AppCheckToken(appCheck.limitedUseAppCheckToken.await().token)
             )
         } catch (e: FirebaseException) {
+            Result.failure(e)
+        } catch (e: Throwable) {
             Result.failure(e)
         }
     }


### PR DESCRIPTION
- add additional catch to get any other errors besides the FirebaseException