### PR TITLE
ci: Fix getting the latest version from last commit

### DIFF
--- a/.github/workflows/on_push-main.yml
+++ b/.github/workflows/on_push-main.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           pattern: 'v*'
 
-      - name: Get next version from branch
+      - name: Get next version from last commit
         id: next-version
         uses: ./config/actions/get-next-version-from-commit-message
 

--- a/config/actions/get-next-version-from-commit-message/action.yml
+++ b/config/actions/get-next-version-from-commit-message/action.yml
@@ -15,17 +15,17 @@ runs:
     - name: Get latest tagged version
       id: get-latest-tag-from-commit-msg
       run: |
-#        Grab last commit message
-        commit_title = $(git log -1 --pretty=%s)
+        echo "$(git log --oneline -n 5)"
+        commit_title=$(git log -1 --pretty=%s | tail -n1)
         
         merged_branch=$(echo "$commit_title" | head -n1)
-        IFS=/ read -r BRANCH_PREFIX BRANCH_SUFFIX <<< "${merged_branch}"
+        IFS=/ read -r BRANCH_PREFIX BRANCH_SUFFIX BRANCH_VERSION <<< "${merged_branch}"
         
-        if [[ "$BRANCH_SUFFIX" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+        if [[ "$BRANCH_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
         then
           NEXT_VERSION="${BASH_REMATCH[0]}"
         else
-          echo "Invalid version in branch name ($GITHUB_REF)"
+          echo "Invalid version in branch name ($commit_title)"
           exit 1
         fi
         


### PR DESCRIPTION
- fixed the versioning and tag push when on-merge-main

Successful versioning: https://github.com/govuk-one-login/mobile-android-one-login-app/actions/runs/16117860439/job/45475872928

There's still a couple of other things that haven't been tested since last change to the versioning process - these can't be tested before getting it merged (e.g. push the tag, etc), so there might be additional changes after this gets merged if any issues are noticed.