### PR TITLE
ci: Push tag fix by changing the way input is handled

### DIFF
--- a/.github/workflows/on_push-main.yml
+++ b/.github/workflows/on_push-main.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Push tag
         id: git-tag
         uses: ./config/actions/push-tag
-        env:
+        with:
           version-name: ${{ steps.version-number.outputs.version }}
 
       - name: Generate version code


### PR DESCRIPTION
- this should enable pushing v1.3.0 tag to remote