### PR TITLE
release/1.3.1

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/login/domain/appintegrity/AppIntegrityImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/domain/appintegrity/AppIntegrityImpl.kt
@@ -43,7 +43,12 @@ class AppIntegrityImpl @Inject constructor(
     }
 
     override suspend fun retrieveSavedClientAttestation(): String? {
-        return getFromOpenSecureStore.invoke(CLIENT_ATTESTATION)?.get(CLIENT_ATTESTATION)
+        // Check if attestation is expired:
+        return if (isAttestationCallRequired()) {
+            null
+        } else {
+            getFromOpenSecureStore.invoke(CLIENT_ATTESTATION)?.get(CLIENT_ATTESTATION)
+        }
     }
 
     private suspend fun handleClientAttestation(result: AttestationResponse.Success) =

--- a/features/src/test/java/uk/gov/onelogin/features/login/domain/appintegrity/AppIntegrityImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/domain/appintegrity/AppIntegrityImplTest.kt
@@ -297,13 +297,28 @@ class AppIntegrityImplTest {
     }
 
     @Test
-    fun `retrieve saved ClientAttestation`() =
+    fun `retrieve saved ClientAttestation success`() =
         runBlocking {
             whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
                 .thenReturn(attestationSsResult)
+            whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY, CLIENT_ATTESTATION))
+                .thenReturn(validAttestationExpSSResult)
             val result = sut.retrieveSavedClientAttestation()
 
             assertEquals(ATTESTATION, result)
+        }
+
+    @Test
+    fun `retrieve saved ClientAttestation failure`() =
+        runBlocking {
+            whenever(featureFlags[AppIntegrityFeatureFlag.ENABLED]).thenReturn(true)
+            whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION))
+                .thenReturn(attestationSsResult)
+            whenever(getFromOpenSecureStore.invoke(CLIENT_ATTESTATION_EXPIRY, CLIENT_ATTESTATION))
+                .thenReturn(invalidAttestationExpSSResult)
+            val result = sut.retrieveSavedClientAttestation()
+
+            assertEquals(null, result)
         }
 
     companion object {


### PR DESCRIPTION
- add missing check for a cached attestation if expired, and if so, to attempt to get a new one

Resolves: DCMAW-14514