### PR TITLE
fix: Fix deeplink not working properly when app is in memory

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/MainActivity.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivity.kt
@@ -44,6 +44,6 @@ class MainActivity : AppCompatActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        viewModel.handleIntent(intent)
+        viewModel.handleIntent(intent) { finish() }
     }
 }

--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -30,8 +30,9 @@ class MainActivityViewModel @Inject constructor(
         }
     }
 
-    fun handleIntent(intent: Intent?) {
+    fun handleIntent(intent: Intent?, finishIntent: () -> Unit = {}) {
         if (intent?.action == ACTION_VIEW && intent.data != null) {
+            finishIntent()
             walletRepository.addDeepLinkPath(intent.data?.path)
             intent.data?.getQueryParameter(OID_QUERY_PARAM)?.let {
                 walletRepository.addCredential(it)

--- a/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavScreen.kt
+++ b/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavScreen.kt
@@ -32,7 +32,6 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import uk.gov.android.onelogin.core.R
 import uk.gov.android.ui.theme.m3.GdsTheme
-import uk.gov.onelogin.features.wallet.ui.WalletScreenViewModel
 import uk.gov.onelogin.mainnav.graphs.BottomNavGraph.bottomGraph
 import uk.gov.ui.components.navigation.GdsNavigationBar
 import uk.gov.ui.components.navigation.GdsNavigationItem
@@ -41,22 +40,22 @@ import uk.gov.ui.components.navigation.GdsNavigationItem
 @Composable
 fun MainNavScreen(
     navController: NavHostController = rememberNavController(),
-    walletScreenViewModel: WalletScreenViewModel = hiltViewModel(),
+    mainNavScreenViewModel: MainNavViewModel = hiltViewModel(),
     analyticsViewModel: MainNavAnalyticsViewModel = hiltViewModel()
 ) {
     val navItems = createBottomNavItems(
-        walletScreenViewModel.walletEnabled,
+        mainNavScreenViewModel.walletEnabled,
         { analyticsViewModel.trackHomeTabButton() },
         { analyticsViewModel.trackWalletTabButton() },
         { analyticsViewModel.trackSettingsTabButton() }
     )
     GdsTheme {
         LifecycleEventEffect(event = Lifecycle.Event.ON_CREATE) {
-            walletScreenViewModel.checkWalletEnabled()
+            mainNavScreenViewModel.checkWalletEnabled()
         }
 
-        LaunchedEffect(walletScreenViewModel.walletDeepLinkReceived) {
-            if (walletScreenViewModel.walletDeepLinkReceived.value) {
+        LaunchedEffect(mainNavScreenViewModel.walletDeepLinkReceived) {
+            if (mainNavScreenViewModel.walletDeepLinkReceived.value) {
                 bottomNav(
                     navController,
                     navItems.first { it.first == BottomNavDestination.Wallet }
@@ -103,7 +102,7 @@ fun MainNavScreen(
             NavHost(
                 navController = navController,
                 startDestination = if (
-                    walletScreenViewModel.walletDeepLinkReceived.value
+                    mainNavScreenViewModel.walletDeepLinkReceived.value
                 ) {
                     BottomNavDestination.Wallet.key
                 } else {

--- a/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/mainnav/ui/MainNavViewModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.onelogin.features.wallet.ui
+package uk.gov.onelogin.mainnav.ui
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
@@ -6,13 +6,11 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import uk.gov.android.featureflags.FeatureFlags
-import uk.gov.android.wallet.sdk.WalletSdk
 import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 import uk.gov.onelogin.features.wallet.data.WalletRepository
 
 @HiltViewModel
-class WalletScreenViewModel @Inject constructor(
-    val walletSdk: WalletSdk,
+class MainNavViewModel @Inject constructor(
     private val features: FeatureFlags,
     private val walletRepository: WalletRepository
 ) : ViewModel() {
@@ -30,13 +28,6 @@ class WalletScreenViewModel @Inject constructor(
         _walletEnabled.value = features[WalletFeatureFlag.ENABLED]
         _walletDeepLinkReceived.value =
             walletRepository.getDeepLinkPath() == DEEPLINK_PATH && _walletEnabled.value
-        walletRepository.resetDeepLinkPath()
-    }
-
-    fun getCredential(): String {
-        val credential = walletRepository.getCredential()
-        walletRepository.resetCredential()
-        return credential
     }
 }
 

--- a/features/src/main/java/uk/gov/onelogin/features/wallet/data/WalletRepository.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/wallet/data/WalletRepository.kt
@@ -5,6 +5,8 @@ interface WalletRepository {
     fun getCredential(): String
     fun addDeepLinkPath(path: String?)
     fun getDeepLinkPath(): String
+    fun resetDeepLinkPath()
+    fun resetCredential()
 }
 
 class WalletRepositoryImpl : WalletRepository {
@@ -25,5 +27,13 @@ class WalletRepositoryImpl : WalletRepository {
 
     override fun getDeepLinkPath(): String {
         return path
+    }
+
+    override fun resetDeepLinkPath() {
+        path = ""
+    }
+
+    override fun resetCredential() {
+        credential = ""
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/wallet/data/WalletRepositoryTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/wallet/data/WalletRepositoryTest.kt
@@ -26,4 +26,23 @@ class WalletRepositoryTest {
         sut.addDeepLinkPath(null)
         assertEquals(expectedPath, sut.getDeepLinkPath())
     }
+
+    @Test
+    fun `verify deeplink reset`() {
+        val setExpected = "hello"
+        val expected = ""
+        sut.addDeepLinkPath("hello")
+        assertEquals(setExpected, sut.getDeepLinkPath())
+        sut.resetDeepLinkPath()
+        assertEquals(expected, sut.getDeepLinkPath())
+    }
+
+    fun `verify credential reset`() {
+        val setExpected = "hello"
+        val expected = ""
+        sut.addCredential("hello")
+        assertEquals(setExpected, sut.getCredential())
+        sut.resetCredential()
+        assertEquals(expected, sut.getCredential())
+    }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModelTest.kt
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.featureflags.FeatureFlags
 import uk.gov.android.wallet.sdk.WalletSdk
@@ -29,6 +31,9 @@ class WalletScreenViewModelTest {
         sut.checkWalletEnabled()
 
         // THEN
+        // Times 2 because once when is initialised, and once when called specifically - this test
+        // all possible use cases when coming in via deeplink and when returning back to the tab from any others
+        verify(walletRepository, times(2)).resetDeepLinkPath()
         assertTrue(sut.walletEnabled.value)
     }
 
@@ -78,6 +83,7 @@ class WalletScreenViewModelTest {
         val actualCredential = sut.getCredential()
 
         // THEN
+        verify(walletRepository).resetCredential()
         assertEquals(expectedCredential, actualCredential)
     }
 


### PR DESCRIPTION
# [fix: Fix deeplink not working properly when app is in memory ](https://govukverify.atlassian.net/browse/DCMAW-14763)

This issue would only happen when the app is open (int he background) and a credential has already been added and removed from he Wallet (it seems the deep link was persisted)

**Changes:**
- add functionality to clear the deep link and credential off saved in memory after it's been passed to the `WalletSdk`
- add a check to `finish()` the intent when `onNewIntent` is called - this allows to reset the previously existing intent - this is done only when the user comes in via deep link to add a Wallet credential
- separate the `WalletScreenViewModel` and the `MainNavViewModel` to allow for specific behaviour that allows the user to add a credential when the app is in memory

## Evidence

https://github.com/user-attachments/assets/0188ed6a-eb1a-4f4b-8a62-4a5c892577c1


Resolves: DCMAW-14763