### PR TITLE
fix: Remove the reset of credential from the deeplink add a credential logic

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModel.kt
@@ -35,7 +35,6 @@ class WalletScreenViewModel @Inject constructor(
 
     fun getCredential(): String {
         val credential = walletRepository.getCredential()
-        walletRepository.resetCredential()
         return credential
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModelTest.kt
@@ -83,7 +83,6 @@ class WalletScreenViewModelTest {
         val actualCredential = sut.getCredential()
 
         // THEN
-        verify(walletRepository).resetCredential()
         assertEquals(expectedCredential, actualCredential)
     }
 


### PR DESCRIPTION
- remove reset of credential offer after passing it to Wallet SDK to allow for new credential to be added


https://github.com/user-attachments/assets/a6808892-f5f4-47cd-b733-e53f9afb23f8



Resolves: https://govukverify.atlassian.net/browse/DCMAW-15369