### PR TITLE
fix: Save tokens in secure store when toggling biometrics on

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/settings/ui/biometricstoggle/BiometricsToggleScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/settings/ui/biometricstoggle/BiometricsToggleScreenViewModel.kt
@@ -1,22 +1,26 @@
 package uk.gov.onelogin.features.settings.ui.biometricstoggle
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import uk.gov.android.featureflags.FeatureFlags
 import uk.gov.android.localauth.LocalAuthManager
 import uk.gov.android.localauth.preference.LocalAuthPreference
 import uk.gov.onelogin.core.navigation.domain.Navigator
+import uk.gov.onelogin.core.tokens.domain.save.SaveTokens
 import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 
 @HiltViewModel
 class BiometricsToggleScreenViewModel @Inject constructor(
     private val featureFlags: FeatureFlags,
     private val localAuthManager: LocalAuthManager,
-    private val navigator: Navigator
+    private val navigator: Navigator,
+    private val saveTokens: SaveTokens
 ) : ViewModel() {
     private val _biometricsEnabled = MutableStateFlow(checkBiometricsEnabledState())
     val biometricsEnabled: StateFlow<Boolean> = _biometricsEnabled.asStateFlow()
@@ -34,6 +38,16 @@ class BiometricsToggleScreenViewModel @Inject constructor(
     }
 
     fun toggleBiometrics() {
+        // only if the initial local auth preference is disabled
+        if (localAuthManager.localAuthPreference is LocalAuthPreference.Disabled) {
+            // then we save the tokens in memory
+            // because the toggle has already been pressed AND this should never show unless the
+            // biometrics are available as we do a check when landing on teh screen (see checkBiometricsAvailable() call point)
+            viewModelScope.launch {
+                saveTokens()
+            }
+        }
+        // toggle the preference
         localAuthManager.toggleBiometrics()
         _biometricsEnabled.value = checkBiometricsEnabledState()
     }

--- a/features/src/test/java/uk/gov/onelogin/features/settings/ui/biometricstoggle/BiometricsToggleScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/settings/ui/biometricstoggle/BiometricsToggleScreenTest.kt
@@ -30,6 +30,7 @@ import uk.gov.logging.api.v3dot1.model.RequiredParameters
 import uk.gov.logging.api.v3dot1.model.TrackEvent
 import uk.gov.logging.api.v3dot1.model.ViewEvent
 import uk.gov.onelogin.core.navigation.domain.Navigator
+import uk.gov.onelogin.core.tokens.domain.save.SaveTokens
 import uk.gov.onelogin.features.FragmentActivityTestCase
 import uk.gov.onelogin.features.featureflags.data.WalletFeatureFlag
 
@@ -38,6 +39,7 @@ class BiometricsToggleScreenTest : FragmentActivityTestCase() {
     private lateinit var featureFlags: FeatureFlags
     private lateinit var localAuthManager: LocalAuthManager
     private lateinit var navigator: Navigator
+    private lateinit var saveTokens: SaveTokens
     private lateinit var viewModel: BiometricsToggleScreenViewModel
     private lateinit var logger: AnalyticsLogger
     private lateinit var analyticsViewModel: BiometricsToggleAnalyticsViewModel
@@ -66,7 +68,13 @@ class BiometricsToggleScreenTest : FragmentActivityTestCase() {
         featureFlags = mock()
         localAuthManager = mock()
         navigator = mock()
-        viewModel = BiometricsToggleScreenViewModel(featureFlags, localAuthManager, navigator)
+        saveTokens = mock()
+        viewModel = BiometricsToggleScreenViewModel(
+            featureFlags = featureFlags,
+            localAuthManager = localAuthManager,
+            navigator = navigator,
+            saveTokens = saveTokens
+        )
         logger = mock()
         analyticsViewModel = BiometricsToggleAnalyticsViewModel(context, logger)
     }


### PR DESCRIPTION
- save tokens only when the state is from Disabled to Biometrics Enabled
- if from passcode or disabling biometrics the behaviour stays the same

**Evidence:**

https://github.com/user-attachments/assets/2ecd51dd-238e-41d2-aa6b-18255e57934f


Resolves: DCMAW-14594