### PR TITLE
feat: Add additional domain for login deeplinking into the app

### DIFF
--- a/app/src/build/res/xml/network_security_config.xml
+++ b/app/src/build/res/xml/network_security_config.xml
@@ -9,6 +9,7 @@
         <domain includeSubdomains="true">token.build.account.gov.uk</domain>
         <domain includeSubdomains="true">auth-stub.mobile.build.account.gov.uk</domain>
         <domain includeSubdomains="true">mobile.build.account.gov.uk</domain>
+        <domain includeSubdomains="true">app.mobile.build.account.gov.uk</domain>
         <pin-set>
             <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>
             <pin digest="SHA-256">f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=</pin>

--- a/app/src/integration/res/xml/network_security_config.xml
+++ b/app/src/integration/res/xml/network_security_config.xml
@@ -9,6 +9,7 @@
         <domain includeSubdomains="true">token.integration.account.gov.uk</domain>
         <domain includeSubdomains="true">auth-stub.mobile.integration.account.gov.uk</domain>
         <domain includeSubdomains="true">mobile.integration.account.gov.uk</domain>
+        <domain includeSubdomains="true">app.mobile.integration.account.gov.uk</domain>
         <domain includeSubdomains="false">api-backend-api.review-b.integration.account.gov.uk</domain>
         <pin-set>
             <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,14 @@
                 <data android:host="mobile${flavorSuffix}.account.gov.uk"/>
                 <data android:path="/redirect"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https"/>
+                <data android:host="app.mobile${flavorSuffix}.account.gov.uk"/>
+                <data android:path="/redirect"/>
+            </intent-filter>
         </activity>
 
         <meta-data android:name="firebase_analytics_collection_enabled" android:value="false" />

--- a/app/src/production/res/xml/network_security_config.xml
+++ b/app/src/production/res/xml/network_security_config.xml
@@ -9,6 +9,7 @@
         <domain includeSubdomains="true">token.account.gov.uk</domain>
         <domain includeSubdomains="true">auth-stub.mobile.account.gov.uk</domain>
         <domain includeSubdomains="true">mobile.account.gov.uk</domain>
+        <domain includeSubdomains="true">app.mobile.account.gov.uk</domain>
         <domain includeSubdomains="false">api-backend-api.review-b.account.gov.uk</domain>
         <pin-set>
             <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>

--- a/app/src/staging/res/xml/network_security_config.xml
+++ b/app/src/staging/res/xml/network_security_config.xml
@@ -9,6 +9,7 @@
         <domain includeSubdomains="true">token.staging.account.gov.uk</domain>
         <domain includeSubdomains="true">auth-stub.mobile.staging.account.gov.uk</domain>
         <domain includeSubdomains="true">mobile.staging.account.gov.uk</domain>
+        <domain includeSubdomains="true">app.mobile.staging.account.gov.uk</domain>
         <domain includeSubdomains="false">api-backend-api.review-b.staging.account.gov.uk</domain>
         <pin-set>
             <pin digest="SHA-256">++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=</pin>


### PR DESCRIPTION
The change on back-end hasn't been done, so cannot be tested, but that is dependent on this and the iOS equivalent getting merged in.
[DCMAW-14910](https://govukverify.atlassian.net/browse/DCMAW-14910)

[app_accepts_both_links.webm](https://github.com/user-attachments/assets/141ed286-17c3-4ec0-93c1-6dfb8d465d80)


Resolves: DCMAW-14910

[DCMAW-14910]: https://govukverify.atlassian.net/browse/DCMAW-14910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ