### PR TITLE
build: Revert "build(deps): bump io.ktor:ktor-client-mock from 3.1.3 to 3.3.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,8 +75,8 @@ jacoco-ant = { module = "org.jacoco:org.jacoco.ant", version.ref = "jacoco" }
 jacoco-core = { module = "org.jacoco:org.jacoco.core", version.ref = "jacoco" }
 jacoco-report = { module = "org.jacoco:org.jacoco.report", version.ref = "jacoco" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.9.0" }
-ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version = "3.3.0" }
-ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version = "3.3.0" }
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version = "3.1.3" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version = "3.1.3" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version = "5.4.0" }
 mockito-android = { group = "org.mockito", name = "mockito-android", version = "5.18.0" }
 navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }


### PR DESCRIPTION
Reverts govuk-one-login/mobile-android-one-login-app#645 due to breaking the network requests