### PR TITLE
fix: Remove automatic sign-in retry from OfflineScreen

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/graphs/ErrorGraphObject.kt
@@ -46,15 +46,7 @@ object ErrorGraphObject {
             ) {
                 OfflineErrorScreen(
                     goBack = { navController.popBackStack() }
-                ) {
-                    navController.apply {
-                        previousBackStackEntry?.savedStateHandle?.set(
-                            OFFLINE_ERROR_TRY_AGAIN_KEY,
-                            true
-                        )
-                        popBackStack()
-                    }
-                }
+                )
             }
             composable(
                 route = ErrorRoutes.UpdateRequired.getRoute()

--- a/app/src/main/java/uk/gov/onelogin/navigation/graphs/LoginGraphObject.kt
+++ b/app/src/main/java/uk/gov/onelogin/navigation/graphs/LoginGraphObject.kt
@@ -13,7 +13,6 @@ import uk.gov.onelogin.features.error.ui.signin.SignInErrorUnrecoverableScreen
 import uk.gov.onelogin.features.login.ui.signin.splash.SplashScreen
 import uk.gov.onelogin.features.login.ui.signin.welcome.WelcomeScreen
 import uk.gov.onelogin.features.optin.ui.OptInScreen
-import uk.gov.onelogin.navigation.graphs.ErrorGraphObject.OFFLINE_ERROR_TRY_AGAIN_KEY
 
 object LoginGraphObject {
     @Suppress("LongMethod")
@@ -37,14 +36,7 @@ object LoginGraphObject {
             composable(
                 route = LoginRoutes.Welcome.getRoute()
             ) {
-                WelcomeScreen(
-                    shouldTryAgain = {
-                        val savedStateHandle = navController.currentBackStackEntry?.savedStateHandle
-                        val tryAgain = savedStateHandle?.get(OFFLINE_ERROR_TRY_AGAIN_KEY) ?: false
-                        savedStateHandle?.remove<Boolean>(OFFLINE_ERROR_TRY_AGAIN_KEY)
-                        tryAgain
-                    }
-                )
+                WelcomeScreen()
             }
 
             composable(

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/offline/OfflineErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/offline/OfflineErrorScreen.kt
@@ -19,8 +19,7 @@ import uk.gov.onelogin.core.ui.pages.EdgeToEdgePage
 @Composable
 fun OfflineErrorScreen(
     analyticsViewModel: OfflineErrorAnalyticsViewModel = hiltViewModel(),
-    goBack: () -> Unit = {},
-    onRetryClick: () -> Unit = {}
+    goBack: () -> Unit = {}
 ) {
     GdsTheme {
         BackHandler(true) {
@@ -31,7 +30,7 @@ fun OfflineErrorScreen(
         EdgeToEdgePage { _ ->
             OfflineErrorBody {
                 analyticsViewModel.trackButton()
-                onRetryClick()
+                goBack()
             }
         }
     }

--- a/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/login/ui/signin/welcome/WelcomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -46,8 +45,7 @@ import uk.gov.onelogin.developer.DeveloperTools
 fun WelcomeScreen(
     viewModel: WelcomeScreenViewModel = hiltViewModel(),
     analyticsViewModel: SignInAnalyticsViewModel = hiltViewModel(),
-    loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel = hiltViewModel(),
-    shouldTryAgain: () -> Boolean = { false }
+    loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel = hiltViewModel()
 ) {
     val loading by viewModel.loading.collectAsState()
     val context = LocalActivity.current as FragmentActivity
@@ -76,14 +74,6 @@ fun WelcomeScreen(
 
     BackHandler(enabled = true) {
         context.finishAndRemoveTask()
-    }
-    LaunchedEffect(key1 = Unit) {
-        if (!shouldTryAgain()) return@LaunchedEffect
-        if (viewModel.onlineChecker.isOnline()) {
-            viewModel.onPrimary(launcher)
-        } else {
-            viewModel.navigateToOfflineError()
-        }
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_START) {

--- a/features/src/test/java/uk/gov/onelogin/features/error/ui/offline/OfflineErrorScreenKtTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/error/ui/offline/OfflineErrorScreenKtTest.kt
@@ -19,7 +19,7 @@ import uk.gov.onelogin.features.FragmentActivityTestCase
 class OfflineErrorScreenKtTest : FragmentActivityTestCase() {
     private lateinit var analytics: AnalyticsLogger
     private lateinit var viewModel: OfflineErrorAnalyticsViewModel
-    private var retryClicked = false
+    private var goBack = false
 
     private val errorTitle = hasText(resources.getString(R.string.app_networkErrorTitle))
     private val errorBody1 = hasText(resources.getString(R.string.app_networkErrorBody1))
@@ -29,13 +29,14 @@ class OfflineErrorScreenKtTest : FragmentActivityTestCase() {
     @Before
     fun setUp() {
         analytics = mock()
+        goBack = false
         viewModel = OfflineErrorAnalyticsViewModel(context, analytics)
-        retryClicked = false
         composeTestRule.setContent {
             OfflineErrorScreen(
-                analyticsViewModel = viewModel,
-                onRetryClick = { retryClicked = true }
-            )
+                analyticsViewModel = viewModel
+            ) {
+                goBack = true
+            }
         }
     }
 
@@ -48,7 +49,7 @@ class OfflineErrorScreenKtTest : FragmentActivityTestCase() {
             assertIsDisplayed()
             performClick()
         }
-        assert(retryClicked)
+        assert(goBack)
         verify(analytics).logEventV3Dot1(OfflineErrorAnalyticsViewModel.makeScreenEvent(context))
         verify(analytics).logEventV3Dot1(OfflineErrorAnalyticsViewModel.makeButtonEvent(context))
     }

--- a/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/login/ui/welcome/WelcomeScreenTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -70,8 +69,6 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
     private lateinit var counter: Counter
     private val logger = SystemLogger()
 
-    private var shouldTryAgainCalled = false
-
     private val signInTitle = hasText(resources.getString(R.string.app_signInTitle))
     private val signInSubTitle1 = hasText(resources.getString(R.string.app_signInBody1))
 
@@ -124,7 +121,6 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
             )
         analyticsViewModel = SignInAnalyticsViewModel(context, analytics)
         loadingAnalyticsVM = LoadingScreenAnalyticsViewModel(context, analytics)
-        shouldTryAgainCalled = false
     }
 
     @Suppress("ForbiddenComment")
@@ -161,57 +157,6 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
             whenWeClickSignIn()
 
             verify(handleRemoteLogin).login(any(), any())
-        }
-
-    @Test
-    fun shouldTryAgainCalledOnPageLoad() {
-        composeTestRule.setContent {
-            WelcomeScreen(
-                analyticsViewModel = analyticsViewModel,
-                viewModel = viewModel,
-                loadingAnalyticsViewModel = loadingAnalyticsVM,
-                shouldTryAgain = {
-                    shouldTryAgainCalled = true
-                    false
-                }
-            )
-        }
-        assertTrue(shouldTryAgainCalled)
-    }
-
-    @Test
-    fun loginFiresAutomaticallyIfOnlineAndShouldTryAgainIsTrue() =
-        runBlocking {
-            whenever(onlineChecker.isOnline()).thenReturn(true)
-            composeTestRule.setContent {
-                WelcomeScreen(
-                    analyticsViewModel = analyticsViewModel,
-                    viewModel = viewModel,
-                    loadingAnalyticsViewModel = loadingAnalyticsVM,
-                    shouldTryAgain = {
-                        true
-                    }
-                )
-            }
-
-            verify(handleRemoteLogin).login(any(), any())
-        }
-
-    @Test
-    fun navigateToErrorScreenIfNotOnlineAndShouldTryAgainIsTrue() =
-        runBlocking {
-            whenever(onlineChecker.isOnline()).thenReturn(false)
-            composeTestRule.setContent {
-                WelcomeScreen(
-                    analyticsViewModel = analyticsViewModel,
-                    viewModel = viewModel,
-                    loadingAnalyticsViewModel = loadingAnalyticsVM,
-                    shouldTryAgain = {
-                        true
-                    }
-                )
-            }
-            verify(navigator).navigate(ErrorRoutes.Offline)
         }
 
     @Test
@@ -261,11 +206,7 @@ class WelcomeScreenTest : FragmentActivityTestCase() {
             WelcomeScreen(
                 analyticsViewModel = analyticsViewModel,
                 viewModel = viewModel,
-                loadingAnalyticsViewModel = loadingAnalyticsVM,
-                shouldTryAgain = {
-                    shouldTryAgainCalled = true
-                    false
-                }
+                loadingAnalyticsViewModel = loadingAnalyticsVM
             )
         }
 


### PR DESCRIPTION
- when user lands on `OfflineScreen`, it will now only be redirected back to the previous page once they click on the primary button and allow the user to try again (sign-in or re-auth won't automatically be retried once they land back on the previous screen, it will now require user interaction to do that)

Resolves: DCMAW-14906