### PR TITLE
ci: Remove unused secrets and permissions from check job

### DIFF
--- a/.github/workflows/on_push_develop.yml
+++ b/.github/workflows/on_push_develop.yml
@@ -25,8 +25,6 @@ jobs:
     permissions:
       # Set permissions for ${{ secrets.GITHUB_TOKEN }}
       # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-      id-token: write
-      contents: write
       packages: read
     steps:
       - name: Run checkout github action
@@ -45,11 +43,6 @@ jobs:
 
       - name: Clean runner
         uses: ./mobile-android-pipelines/actions/clean-runner-fast
-
-      - name: Retrieve secrets
-        uses: ./config/actions/retrieve-secrets
-        with:
-          actions-role-arn: ${{ secrets.GITHUBRUNNER_EC2_ACTIONS_ROLE_ARN }}
 
       - name: Get latest tag
         id: latest-tag


### PR DESCRIPTION
## Changes

Remove unused secrets and permissions from the `run-checks` job that runs on push to `develop`:

- Remove `id-token: write` permission
- Remove `contents: write` permission
- Remove Google Play service account access
- Remove signing keystore file

## Context

These permissions shouldn't be needed in this job since splitting checks from deployment in #705 