### PR TITLE
build: Update mobile-android-pipelines from `b5d0ac4` to `2318c33`

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -41,6 +41,9 @@ jobs:
         id: detect-arch
         uses: ./config/actions/detect-arch
 
+      - name: Setup prerequisite dependencies
+        uses: ./mobile-android-pipelines/actions/common-prerequisites
+
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
 

--- a/.github/workflows/on_push_develop.yml
+++ b/.github/workflows/on_push_develop.yml
@@ -38,6 +38,9 @@ jobs:
         id: detect-arch
         uses: ./config/actions/detect-arch
 
+      - name: Setup prerequisite dependencies
+        uses: ./mobile-android-pipelines/actions/common-prerequisites
+
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
 

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -34,6 +34,9 @@ jobs:
         id: detect-arch
         uses: ./config/actions/detect-arch
 
+      - name: Setup prerequisite dependencies
+        uses: ./mobile-android-pipelines/actions/common-prerequisites
+
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
 

--- a/.github/workflows/on_schedule.yml
+++ b/.github/workflows/on_schedule.yml
@@ -33,6 +33,9 @@ jobs:
         id: detect-arch
         uses: ./config/actions/detect-arch
 
+      - name: Setup prerequisite dependencies
+        uses: ./mobile-android-pipelines/actions/common-prerequisites
+
       - name: Setup GitHub Runner workflow
         uses: ./mobile-android-pipelines/actions/setup-runner
 


### PR DESCRIPTION
## Changes

- Update mobile-android-pipelines from `b5d0ac4` to `2318c33` (https://github.com/govuk-one-login/mobile-android-pipelines/compare/b5d0ac4f6d5ca358beab60cd46a6681fc4f60531...2318c330bc80c5f642300412088fa3205ac7a2bc)
- Run `./mobile-android-pipelines/actions/common-prerequisites` in any job that needs vale installed

## Context

The new version of mobile-android-pipelines uses the `setup-gradle` action version 6.1.0 which changes the way cache keys are calculated (https://github.com/govuk-one-login/mobile-android-pipelines/pull/301).

This mobile-android-pipelines update is a breaking change as vale has been removed from the set of software that is installed by default (https://github.com/govuk-one-login/mobile-android-pipelines/pull/296).

DCMAW-19663

