### PR TITLE
ci: Don't re-run PR checks on 'ready for review'

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -11,7 +11,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - ready_for_review
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Changes

Remove the `ready_for_review` trigger for PR workflows.

## Context

Avoids time wasted re-running workflows when the author marks their PR as 'ready for review' (i.e. no code has changed).