### PR TITLE
build: separate dep submission into its own job

### DIFF
--- a/.github/workflows/on_push_develop.yml
+++ b/.github/workflows/on_push_develop.yml
@@ -126,18 +126,56 @@ jobs:
           version-name: ${{ steps.version-name.outputs.version-name }}
           app-check-token: ${{ secrets.BUILD_APPCHECK_DEBUG_TOKEN }}
 
+      - name: Clean workspace
+        if: always()
+        uses: ./mobile-android-pipelines/actions/clean-workspace
+
+  dependency-submission-job:
+    name: Generate and submit dependency graph
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      packages: read
+
+    steps:
+      - name: Run checkout github action
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          lfs: 'true'
+          submodules: 'true'
+          fetch-depth: 0
+
+      - name: Detect Arch
+        id: detect-arch
+        uses: ./config/actions/detect-arch
+
+      - name: Setup GitHub Runner workflow
+        uses: ./mobile-android-pipelines/actions/setup-runner
+
+      - name: Clean runner
+        uses: ./mobile-android-pipelines/actions/clean-runner-fast
+
+      - name: Get latest tag
+        id: latest-tag
+        uses: ./config/actions/get-latest-tag
+        with:
+          pattern: 'v*'
+
+      - name: Generate version code
+        id: version-code
+        uses: ./mobile-android-pipelines/actions/generate-version-code
+
       - name: Generate and submit dependency graph
         uses: ./mobile-android-pipelines/actions/dependency-submission
         with:
           additional-arguments:
-            -Pgpr.user=${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
+            -Pgpr.user=${{ secrets.MODULE_FETCH_TOKEN_USERNAME }} 
             -Pgpr.token=${{ secrets.MODULE_FETCH_TOKEN }}
             -PversionName="${{ steps.latest-tag.outputs.current-tag }}-${{ steps.version-code.outputs.version-code }}"
             -PversionCode=${{ steps.version-code.outputs.version-code }}
             -PdebugBuildAppCheckToken=${{ secrets.BUILD_APPCHECK_DEBUG_TOKEN }}
 
       - name: Clean workspace
-        if: always()
         uses: ./mobile-android-pipelines/actions/clean-workspace
 
   bundle-and-publish:


### PR DESCRIPTION
### Context

On Develop pipeline failed because dependency submission step didn't have permission to write to the repo. It is now in a separate job with the required permission