### PR TITLE
docs: Update App Integrity developer docs

### DIFF
--- a/docs/developer-setup/app-integrity.md
+++ b/docs/developer-setup/app-integrity.md
@@ -1,10 +1,25 @@
 ### App Integrity
 
-As part of the login process [Firebase App Check](https://firebase.google.com/docs/app-check/android/play-integrity-provider)
-is used in conjunction with some backend functions to ensure we are dealing with a
-legitimate version of the app.
+As part of the login process [Firebase App Check](https://firebase.google.com/docs/app-check/android/play-integrity-provider) is used in conjunction with some backend 
+functions to ensure we are dealing with a legitimate version of the app.
 
-To build the app it requires that a `debugAppCheckToken` is provided. This should be set in
-your local `~/.gradle/gradle.properties` file. This is a debug secret and will need to be
-acquired via the relevant internal channels. However the app should build if there is an empty 
-or 'dummy' string in the `gradle.properties` file.
+To build and debug the app, you will need a [debug App Check token] for the variant you want to run.
+
+1. Get debug App Check tokens for the build and staging environments.
+   
+   These are debug secrets and will need to be acquired via the relevant internal channels (see
+   [how to get a debug App Check token (internal)]).
+
+2. Add the tokens to your local `~/.gradle/gradle.properties`
+
+```properties
+# ~/.gradle/gradle.properties
+
+debugBuildAppCheckToken=<your app check token for the build environment>
+debugStagingAppCheckToken=<your app check token for the staging environment>
+```
+
+Note that the app should build if there is an empty or 'dummy' string in the `gradle.properties` file.
+
+[debug App Check token]: https://firebase.google.com/docs/app-check/android/debug-provider
+[how to get a debug App Check token (internal)]: https://govukverify.atlassian.net/wiki/x/EYB4FQE

--- a/docs/developer-setup/app-integrity.md
+++ b/docs/developer-setup/app-integrity.md
@@ -3,7 +3,10 @@
 As part of the login process [Firebase App Check](https://firebase.google.com/docs/app-check/android/play-integrity-provider) is used in conjunction with some backend 
 functions to ensure we are dealing with a legitimate version of the app.
 
-To build and debug the app, you will need a [debug App Check token] for the variant you want to run.
+So, to run the production or integration variant of the app, you'll need to install a release build
+from Google Play.
+
+To build and debug locally, you'll need to use the build or staging variant of the app with a [debug App Check token]:
 
 1. Get debug App Check tokens for the build and staging environments.
    


### PR DESCRIPTION
## Changes

- Update `debugAppCheckToken` to `debugBuildAppCheckToken` and `debugStagingAppCheckToken`
- Add links to relevant documentation

[Rendered](https://github.com/govuk-one-login/mobile-android-one-login-app/blob/9d561931f06aaff3a0ff22ce9e1e1a39b6397906/docs/developer-setup/app-integrity.md)