### PR TITLE
chore: Update MOD certificate pinning config for integration environment

### DIFF
--- a/app/src/integration/res/xml/network_security_config.xml
+++ b/app/src/integration/res/xml/network_security_config.xml
@@ -22,8 +22,7 @@
     <domain-config>
         <domain includeSubdomains="false">vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk</domain>
         <pin-set>
-            <pin digest="SHA-256">CLcBxJ0axyguKJiapmJ5QQHO6hpXTbn7atGEto6ruSY=</pin>
-            <pin digest="SHA-256">R3hcMOAGw0WFztuG2skTodoHp8IGid3Qg63Cn7YUYoM=</pin>
+            <pin digest="SHA-256">Douxi77vs4G+Ib/BogbTFymEYq0QSFXwSgVCaZcI09Q=</pin>
         </pin-set>
     </domain-config>
     <domain-config>


### PR DESCRIPTION
## Changes

- Add new certificate pinning configuration for the MOD domain `vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk`.
- Remove old pins for this domain.

This PR only updates the config for the integration environment app.

## Context

DCMAW-20098