### PR TITLE
refactor: Replace usage of internal Wallet SDK constant with local constant

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/DeeplinkActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/DeeplinkActivityViewModel.kt
@@ -6,10 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
-import uk.gov.android.wallet.core.issuer.verify.VerifyCredentialIssuerImpl.Companion.OID_QUERY_PARAM
 import uk.gov.android.wallet.sdk.WalletSdk
 import uk.gov.onelogin.features.wallet.data.WalletRepository
 import javax.inject.Inject
+
+private const val CREDENTIAL_OFFER_QUERY_PARAM_KEY = "credential_offer"
 
 @HiltViewModel
 @Suppress("LongParameterList")
@@ -21,10 +22,10 @@ class DeeplinkActivityViewModel
     ) : ViewModel() {
         fun handleIntent(intent: Intent?) {
             if (intent?.action == ACTION_VIEW && intent.data != null) {
-                intent.data?.getQueryParameter(OID_QUERY_PARAM)?.let {
+                intent.data?.getQueryParameter(CREDENTIAL_OFFER_QUERY_PARAM_KEY)?.let { credentialOffer ->
                     viewModelScope.launch {
                         walletRepository.setWalletDeepLinkPathState(deepLink = true)
-                        walletSdk.setDeeplink(deeplink = it)
+                        walletSdk.setDeeplink(deeplink = credentialOffer)
                     }
                 }
             }

--- a/app/src/test/java/uk/gov/onelogin/DeeplinkActivityViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/DeeplinkActivityViewModelTest.kt
@@ -10,7 +10,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.android.wallet.sdk.WalletSdk
@@ -44,7 +43,7 @@ class DeeplinkActivityViewModelTest {
             viewModel.handleIntent(intent)
 
             verify(walletRepository).setWalletDeepLinkPathState(deepLink = true)
-            verify(walletSdk).setDeeplink(any())
+            verify(walletSdk).setDeeplink(credentialOffer)
         }
 
     @Test


### PR DESCRIPTION
## Changes

Replace usage of internal Wallet SDK constant (`uk.gov.android.wallet.core.issuer.verify.VerifyCredentialIssuerImpl.Companion.OID_QUERY_PARAM`) with local constant.

## Context

Prepare for Wallet SDK v2.275.1 where `OID_QUERY_PARAM` is no longer accessible.

- https://github.com/govuk-one-login/mobile-android-one-login-app/pull/839#issuecomment-4379258424