### PR TITLE
ci: Add lint for GitHub Actions workflows

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -297,8 +297,6 @@ jobs:
   sonar-analysis:
     name: Run sonar analysis and check sonar quality gate
     runs-on: ubuntu-22.04
-    outputs:
-      status: ${{ steps.sonar-gate.outputs.status }}
     needs:
       - set-up
       - style-checks
@@ -336,7 +334,7 @@ jobs:
       - name: Run sonar analysis
         uses: ./config/actions/sonar-analysis
         with:
-          project-version: ${{ steps.version-name.outputs.version-name }}
+          project-version: ${{ needs.set-up.outputs.version-name }}
           sonar-token: ${{ secrets.SONAR_TOKEN }}
           version-code: ${{ needs.set-up.outputs.version-code }}
           version-name: ${{ needs.set-up.outputs.version-name }}

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -355,3 +355,14 @@ jobs:
 
       - name: Clean workspace
         uses: ./mobile-android-pipelines/actions/clean-workspace
+        
+  lint-github-actions:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Lint GitHub Actions
+        uses: alphagov/govuk-infrastructure/.github/actions/actionlint@2eae2110aa84499c1ce30ed3d493b0cd41df6b6f # main


### PR DESCRIPTION
## Changes

Add lint action for GitHub Actions workflows.

## Evidence

- https://github.com/govuk-one-login/mobile-android-one-login-app/pull/847/commits/bfb1ebb68bb65afa82dccb848faec387fb1662d6: [Job fails](https://github.com/govuk-one-login/mobile-android-one-login-app/actions/runs/25486764467/job/74784382498?pr=847) due to problems with the workflow.
- https://github.com/govuk-one-login/mobile-android-one-login-app/pull/847/commits/8a2d946992b917d160e247ac1be486cbb0d59897: [Job passes](https://github.com/govuk-one-login/mobile-android-one-login-app/actions/runs/25486982902/job/74785170796?pr=847) after fixes

## Context

DCMAW-20179

Helps prevent workflow regressions such as broken references in GitHub Actions.

Follows the same pattern as [mobile-android-cri-orchestrator/blob/main/.github/workflows/lint.yml](https://github.com/govuk-one-login/mobile-android-cri-orchestrator/blob/main/.github/workflows/lint.yml#L74-L83) which also uses [alphagov/govuk-infrastructure](https://github.com/alphagov/govuk-infrastructure)'s GitHub action.