### PR TITLE
chore: Update MOD certificate pinning config for build and staging envs

### DIFF
--- a/app/src/build/res/xml/network_security_config.xml
+++ b/app/src/build/res/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
@@ -21,7 +21,7 @@
     <domain-config>
         <!-- Note that this domain isn't yet used by the app in the build environment -->
         <domain includeSubdomains="false">vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk</domain>
-        <pin-set>
+        <pin-set tools:ignore="MissingBackupPin">
             <pin digest="SHA-256">Douxi77vs4G+Ib/BogbTFymEYq0QSFXwSgVCaZcI09Q=</pin>
         </pin-set>
     </domain-config>

--- a/app/src/build/res/xml/network_security_config.xml
+++ b/app/src/build/res/xml/network_security_config.xml
@@ -19,10 +19,10 @@
         </pin-set>
     </domain-config>
     <domain-config>
+        <!-- Note that this domain isn't yet used by the app in the build environment -->
         <domain includeSubdomains="false">vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk</domain>
         <pin-set>
-            <pin digest="SHA-256">CLcBxJ0axyguKJiapmJ5QQHO6hpXTbn7atGEto6ruSY=</pin>
-            <pin digest="SHA-256">R3hcMOAGw0WFztuG2skTodoHp8IGid3Qg63Cn7YUYoM=</pin>
+            <pin digest="SHA-256">Douxi77vs4G+Ib/BogbTFymEYq0QSFXwSgVCaZcI09Q=</pin>
         </pin-set>
     </domain-config>
 </network-security-config>

--- a/app/src/staging/res/xml/network_security_config.xml
+++ b/app/src/staging/res/xml/network_security_config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />
@@ -22,7 +22,7 @@
     <domain-config>
         <!-- Note that this domain isn't yet used by the app in the staging environment app -->
         <domain includeSubdomains="false">vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk</domain>
-        <pin-set>
+        <pin-set tools:ignore="MissingBackupPin">
             <pin digest="SHA-256">Douxi77vs4G+Ib/BogbTFymEYq0QSFXwSgVCaZcI09Q=</pin>
         </pin-set>
     </domain-config>

--- a/app/src/staging/res/xml/network_security_config.xml
+++ b/app/src/staging/res/xml/network_security_config.xml
@@ -20,10 +20,10 @@
         </pin-set>
     </domain-config>
     <domain-config>
+        <!-- Note that this domain isn't yet used by the app in the staging environment app -->
         <domain includeSubdomains="false">vvrc-credential-issuance-service-dbs-ag-vvrc-staging.apps.ocp1.azure.dso.digital.mod.uk</domain>
         <pin-set>
-            <pin digest="SHA-256">CLcBxJ0axyguKJiapmJ5QQHO6hpXTbn7atGEto6ruSY=</pin>
-            <pin digest="SHA-256">R3hcMOAGw0WFztuG2skTodoHp8IGid3Qg63Cn7YUYoM=</pin>
+            <pin digest="SHA-256">Douxi77vs4G+Ib/BogbTFymEYq0QSFXwSgVCaZcI09Q=</pin>
         </pin-set>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Changes

- Update MOD certificate pinning config for build and staging environments.
- Add a note explaining that the domains aren't used in these environments.

## Context

Follow up to
- #838

Keep the pinning configuration so that it applies to integration and lower.

Align the pinning configuration with the integration environment so that certificates remain valid regardless.

DCMAW-20098

