### PR TITLE
feat: Upgrade error screens to use Error Screen pattern

### DIFF
--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -159,7 +159,6 @@
     <string name="app_updateAppBody1">You’re using an old version of the GOV.UK One Login app.</string>
     <string name="app_updateAppBody2">Update your app to continue.</string>
     <string name="app_updateAppButton">Update GOV.UK One Login app</string>
-    <string name="app_updateApp_ContentDescription" translatable="false">Update App Required icon content description</string>
 
     <!-- Re-Auth Error -->
     <string name="app_dataDeletedErrorTitle">Something went wrong</string>

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/unavailable/AppUnavailableScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/unavailable/AppUnavailableScreen.kt
@@ -1,47 +1,30 @@
 package uk.gov.onelogin.features.error.ui.unavailable
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.navigation.compose.rememberNavController
 import uk.gov.android.onelogin.core.R
+import uk.gov.android.ui.componentsv2.heading.GdsHeading
+import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
+import uk.gov.android.ui.componentsv2.images.GdsIcon
+import uk.gov.android.ui.patterns.errorscreen.v2.ErrorScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
-import uk.gov.android.ui.theme.smallPadding
-import uk.gov.android.ui.theme.spacingDouble
+import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
 import uk.gov.onelogin.core.navigation.domain.closeApp
 import uk.gov.onelogin.core.ui.meta.ExcludeFromJacocoGeneratedReport
 import uk.gov.onelogin.core.ui.meta.ScreenPreview
 import uk.gov.onelogin.core.ui.pages.EdgeToEdgePage
-import uk.gov.android.ui.patterns.R as Res
-
-internal const val ICON_TAG = "icon.tag"
-private val iconSize = 100.dp
-private val iconPadding = 1.dp
+import uk.gov.onelogin.core.utils.ModifierExtensions.errorBodyItemModifier
+import uk.gov.android.ui.patterns.R as patternsR
 
 @Composable
 fun AppUnavailableScreen(analyticsViewModel: AppUnavailableAnalyticsViewModel = hiltViewModel()) {
@@ -56,54 +39,35 @@ fun AppUnavailableScreen(analyticsViewModel: AppUnavailableAnalyticsViewModel = 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { analyticsViewModel.trackUnavailableView() }
 }
 
+@OptIn(UnstableDesignSystemAPI::class)
 @Composable
 internal fun AppUnavailableBody() {
-    // Update typography references when UI is updated
-    val color = colorScheme.contentColorFor(colorScheme.background)
-    EdgeToEdgePage {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(smallPadding),
-            contentAlignment = Alignment.Center,
-        ) {
-            Column(
-                modifier = Modifier.verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(spacingDouble, Alignment.Top),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Icon(
-                    modifier =
-                        Modifier
-                            .padding(iconPadding)
-                            .size(iconSize)
-                            .testTag(ICON_TAG),
-                    painter = painterResource(Res.drawable.ic_warning_error),
-                    contentDescription = null,
-                    tint = color,
+    EdgeToEdgePage { _ ->
+        ErrorScreen(
+            icon = { horizontalPadding ->
+                GdsIcon(
+                    image = ImageVector.vectorResource(patternsR.drawable.ic_warning_error),
+                    contentDescription = stringResource(patternsR.string.error_icon_description),
+                    modifier = Modifier.errorBodyItemModifier(horizontalPadding),
                 )
-                Text(
-                    color = color,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .semantics { heading() },
-                    style = MaterialTheme.typography.headlineLarge, // `displaySmall`
+            },
+            title = { horizontalPadding ->
+                GdsHeading(
                     text = stringResource(R.string.app_appUnavailableTitle),
-                    textAlign = TextAlign.Center,
+                    modifier = Modifier.errorBodyItemModifier(horizontalPadding),
+                    textAlign = GdsHeadingAlignment.CenterAligned,
                 )
-                Text(
-                    color = color,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth(),
-                    style = MaterialTheme.typography.bodyLarge, // `bodySmall`
-                    text = stringResource(R.string.app_appUnavailableBody),
-                    textAlign = TextAlign.Center,
-                )
-            }
-        }
+            },
+            body = { horizontalPadding ->
+                item {
+                    Text(
+                        text = stringResource(R.string.app_appUnavailableBody),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.errorBodyItemModifier(horizontalPadding),
+                    )
+                }
+            },
+        )
     }
 }
 

--- a/features/src/main/java/uk/gov/onelogin/features/error/ui/update/OutdatedAppErrorScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/error/ui/update/OutdatedAppErrorScreen.kt
@@ -1,22 +1,13 @@
 package uk.gov.onelogin.features.error.ui.update
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -29,15 +20,16 @@ import uk.gov.android.ui.componentsv2.button.ButtonTypeV2
 import uk.gov.android.ui.componentsv2.button.GdsButton
 import uk.gov.android.ui.componentsv2.heading.GdsHeading
 import uk.gov.android.ui.componentsv2.heading.GdsHeadingAlignment
+import uk.gov.android.ui.componentsv2.images.GdsIcon
+import uk.gov.android.ui.patterns.errorscreen.v2.ErrorScreen
 import uk.gov.android.ui.theme.m3.GdsTheme
-import uk.gov.android.ui.theme.mediumPadding
-import uk.gov.android.ui.theme.smallPadding
 import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
 import uk.gov.onelogin.core.navigation.domain.closeApp
 import uk.gov.onelogin.core.ui.meta.ExcludeFromJacocoGeneratedReport
 import uk.gov.onelogin.core.ui.meta.ScreenPreview
 import uk.gov.onelogin.core.ui.pages.EdgeToEdgePage
-import uk.gov.android.ui.patterns.R as UiR
+import uk.gov.onelogin.core.utils.ModifierExtensions.errorBodyItemModifier
+import uk.gov.android.ui.patterns.R as patternsR
 
 @Composable
 fun ErrorUpdateRequiredScreen(
@@ -60,68 +52,56 @@ fun ErrorUpdateRequiredScreen(
 
 @OptIn(UnstableDesignSystemAPI::class)
 @Composable
-@Suppress("LongMethod")
-internal fun UpdateRequiredBody(onPrimary: () -> Unit) {
+internal fun UpdateRequiredBody(onPrimary: () -> Unit = {}) {
     val buttonText = stringResource(R.string.app_updateAppButton)
     val buttonAccessibilityDesc = stringResource(R.string.app_openGooglePlayStore)
     GdsTheme {
         EdgeToEdgePage { _ ->
-            Column(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(mediumPadding),
-                verticalArrangement = Arrangement.Center,
-            ) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                    modifier =
-                        Modifier
-                            .verticalScroll(rememberScrollState())
-                            .weight(1f)
-                            .padding(bottom = smallPadding),
-                ) {
-                    Image(
-                        painter = painterResource(UiR.drawable.ic_warning_error),
-                        contentDescription =
-                            stringResource(
-                                R.string.app_updateApp_ContentDescription,
-                            ),
-                        modifier = Modifier.padding(mediumPadding),
-                        colorFilter =
-                            ColorFilter.tint(
-                                color = MaterialTheme.colorScheme.onBackground,
-                            ),
+            ErrorScreen(
+                icon = { padding ->
+                    GdsIcon(
+                        image = ImageVector.vectorResource(patternsR.drawable.ic_warning_error),
+                        contentDescription = stringResource(patternsR.string.error_icon_description),
+                        modifier = Modifier.errorBodyItemModifier(padding),
                     )
+                },
+                title = { padding ->
                     GdsHeading(
                         text = stringResource(R.string.app_updateApp_Title),
-                        modifier = Modifier.padding(bottom = smallPadding),
+                        modifier = Modifier.errorBodyItemModifier(padding),
                         textAlign = GdsHeadingAlignment.CenterAligned,
                     )
-                    Text(
-                        text = stringResource(R.string.app_updateAppBody1),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge,
+                },
+                body = { padding ->
+                    item {
+                        Text(
+                            text = stringResource(R.string.app_updateAppBody1),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.errorBodyItemModifier(padding),
+                        )
+                    }
+                    item {
+                        Text(
+                            text = stringResource(R.string.app_updateAppBody2),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.errorBodyItemModifier(padding),
+                        )
+                    }
+                },
+                primaryButton = {
+                    GdsButton(
+                        text = buttonText,
+                        buttonType = ButtonTypeV2.Primary(),
+                        onClick = onPrimary,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .semantics(mergeDescendants = true) {
+                                    contentDescription = buttonText + buttonAccessibilityDesc
+                                },
                     )
-                    Text(
-                        text = stringResource(R.string.app_updateAppBody2),
-                        textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.bodyLarge,
-                    )
-                }
-                GdsButton(
-                    text = buttonText,
-                    buttonType = ButtonTypeV2.Primary(),
-                    onClick = onPrimary,
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .semantics(mergeDescendants = true) {
-                                contentDescription = buttonText + buttonAccessibilityDesc
-                            },
-                )
-            }
+                },
+            )
         }
     }
 }

--- a/features/src/test/java/uk/gov/onelogin/features/component/error/update/ErrorUpdateRequiredErrorScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/component/error/update/ErrorUpdateRequiredErrorScreenTest.kt
@@ -29,6 +29,7 @@ import uk.gov.onelogin.features.appinfo.AppInfoUtils
 import uk.gov.onelogin.features.error.ui.update.ErrorUpdateRequiredScreen
 import uk.gov.onelogin.features.error.ui.update.OutdatedAppErrorAnalyticsViewModel
 import uk.gov.onelogin.features.error.ui.update.OutdatedAppErrorViewModel
+import uk.gov.android.ui.patterns.R as patternsR
 
 @RunWith(AndroidJUnit4::class)
 class ErrorUpdateRequiredErrorScreenTest : FragmentActivityTestCase() {
@@ -63,7 +64,7 @@ class ErrorUpdateRequiredErrorScreenTest : FragmentActivityTestCase() {
         }
         composeTestRule.apply {
             onNodeWithContentDescription(
-                resources.getString(R.string.app_updateApp_ContentDescription)
+                resources.getString(patternsR.string.error_icon_description)
             ).assertIsDisplayed()
 
             onNodeWithText(

--- a/features/src/test/java/uk/gov/onelogin/features/unit/error/ui/unavailable/AppUnavailableBodyTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/error/ui/unavailable/AppUnavailableBodyTest.kt
@@ -3,7 +3,7 @@ package uk.gov.onelogin.features.unit.error.ui.unavailable
 import android.content.Context
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith
 import uk.gov.android.onelogin.core.R
 import uk.gov.onelogin.features.FragmentActivityTestCase
 import uk.gov.onelogin.features.error.ui.unavailable.AppUnavailableBody
-import uk.gov.onelogin.features.error.ui.unavailable.ICON_TAG
+import uk.gov.android.ui.patterns.R as patternsR
 
 @RunWith(AndroidJUnit4::class)
 class AppUnavailableBodyTest : FragmentActivityTestCase() {
@@ -24,7 +24,7 @@ class AppUnavailableBodyTest : FragmentActivityTestCase() {
     @Before
     fun setUp() {
         val context: Context = ApplicationProvider.getApplicationContext()
-        icon = hasTestTag(ICON_TAG)
+        icon = hasContentDescription(context.getString(patternsR.string.error_icon_description))
         header = hasText(context.getString(R.string.app_appUnavailableTitle))
         content = hasText(context.getString(R.string.app_appUnavailableBody))
     }

--- a/features/src/test/java/uk/gov/onelogin/features/unit/error/ui/update/ErrorUpdateRequiredBodyTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/error/ui/update/ErrorUpdateRequiredBodyTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import uk.gov.android.onelogin.core.R
 import uk.gov.onelogin.features.FragmentActivityTestCase
 import uk.gov.onelogin.features.error.ui.update.UpdateRequiredBody
+import uk.gov.android.ui.patterns.R as patternsR
 
 @RunWith(AndroidJUnit4::class)
 class ErrorUpdateRequiredBodyTest : FragmentActivityTestCase() {
@@ -32,7 +33,7 @@ class ErrorUpdateRequiredBodyTest : FragmentActivityTestCase() {
         body1 = hasText(context.getString(R.string.app_updateAppBody1))
         body2 = hasText(context.getString(R.string.app_updateAppBody2))
         primaryButton = hasText(context.getString(R.string.app_updateAppButton))
-        icon = hasContentDescription(context.getString(R.string.app_updateApp_ContentDescription))
+        icon = hasContentDescription(context.getString(patternsR.string.error_icon_description))
     }
 
     @Test


### PR DESCRIPTION
## Changes

- Upgrade AppUnavailableScreen to use Error Screen pattern
- Upgrade ErrorUpdateRequiredScreen to use Error Screen pattern

## Context

After this change, these error screens inherit the correct accessibility behaviour from the Design System pattern.

[DCMAW-17658](https://govukverify.atlassian.net/browse/DCMAW-17658)

## Evidence

### App Unavailable Screen

[Screen_recording_20260512_121739.webm](https://github.com/user-attachments/assets/dd564b50-f625-441d-92c6-94f954eb46eb) 

### Error Update Required Screen

[Screen_recording_20260512_105850.webm](https://github.com/user-attachments/assets/e4b064f9-80a5-4383-8324-e3c42ed397c8)

[DCMAW-17658]: https://govukverify.atlassian.net/browse/DCMAW-17658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ