### PR TITLE
build: Fix obscure error on absent Firebase App Check debug token

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ buildscript {
             providers.gradleProperty("debugBuildAppCheckToken").get()
         }  catch (e: org.gradle.api.internal.provider.MissingValueException) {
             logger.warn("firebase debug build token not found in gradle properties")
-            System.getenv("BUILD_DEBUG_APP_CHECK_TOKEN")
+            System.getenv("BUILD_DEBUG_APP_CHECK_TOKEN") ?: ""
         }
     )
     val debugStagingAppCheckToken: String by rootProject.extra(


### PR DESCRIPTION
## Changes

- Fall back to empty string when Firebase App Check debug token is unavailable

## Context

Fixes an obscure build error when the Gradle property isn't available:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> java.lang.NullPointerException: null cannot be cast to non-null type kotlin.String
```