### PR TITLE
ci: Fix versioning for builds published from release branches

### DIFF
--- a/.github/workflows/on_push_release.yml
+++ b/.github/workflows/on_push_release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       version-code: ${{ steps.version-code.outputs.version-code }}
-      version-name: ${{ steps.version-name.outputs.version-name }}
+      version-name: ${{ steps.next-version.outputs.next-version }}
 
     steps:
       - name: Run checkout github action
@@ -54,13 +54,6 @@ jobs:
         env:
           CURRENT_VERSION: ${{ steps.latest-tag.outputs.current-tag }}
           NEXT_VERSION: ${{ steps.version-number.outputs.version }}
-
-      - name: Generate version name
-        id: version-name
-        uses: ./mobile-android-pipelines/actions/version-name
-        with:
-          version-code: ${{ steps.version-code.outputs.version-code }}
-          version-name: ${{ steps.next-version.outputs.next-version }}
 
       - name: Clean workspace
         uses: ./mobile-android-pipelines/actions/clean-workspace


### PR DESCRIPTION
## Changes

Fixes the version of apps published from release branches (both build and staging environments).

### Before

Version is prefixed with the version code e.g. `123456-1.2.3`.

### After

Version is in Semantic Versioning format e.g `1.2.3`.

## Context

[DCMAW-20175](https://govukverify.atlassian.net/browse/DCMAW-20175)

- #819 

Note that the 'before' behaviour is correct for builds published from the develop branch (by on_push_develop.yml). No change is needed for that workflow.

[DCMAW-20175]: https://govukverify.atlassian.net/browse/DCMAW-20175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ