### PR TITLE
refactor: Upgrade V2 Logger to V3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -179,6 +179,7 @@ dependencies {
         libs.uiautomator,
         libs.mockito.kotlin,
         libs.mockito.android,
+        testFixtures(libs.logging.api),
     ).forEach(::androidTestImplementation)
 
     listOf(

--- a/app/src/androidTest/java/uk/gov/onelogin/mainnav/ui/MainNavScreenTest.kt
+++ b/app/src/androidTest/java/uk/gov/onelogin/mainnav/ui/MainNavScreenTest.kt
@@ -25,6 +25,7 @@ import uk.gov.android.onelogin.core.R
 import uk.gov.logging.api.CrashLogger
 import uk.gov.logging.api.Logger
 import uk.gov.logging.api.analytics.logging.AnalyticsLogger
+import uk.gov.logging.api.v3.MemorisedLogger
 import uk.gov.logging.api.v3dot1.logger.logEventV3Dot1
 import uk.gov.onelogin.core.AnalyticsModule
 import uk.gov.onelogin.featureflags.FeaturesModule
@@ -33,7 +34,7 @@ import uk.gov.onelogin.features.wallet.data.WalletRepository
 import uk.gov.onelogin.utils.TestCase
 import uk.gov.onelogin.wallet.WalletRepositoryModule
 import uk.gov.android.wallet.core.R as walletR
-import uk.gov.logging.api.v2.Logger as LoggerV2
+import uk.gov.logging.api.v3.Logger as LoggerV3
 
 @HiltAndroidTest
 @UninstallModules(FeaturesModule::class, AnalyticsModule::class, WalletRepositoryModule::class)
@@ -58,7 +59,7 @@ class MainNavScreenTest : TestCase() {
     val crashLogger: CrashLogger = mock()
 
     @BindValue
-    val logger2: LoggerV2 = mock()
+    val logger3: LoggerV3 = MemorisedLogger()
 
     @BindValue
     val walletRepository: WalletRepository = mock()

--- a/app/src/main/java/uk/gov/onelogin/core/AnalyticsModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/core/AnalyticsModule.kt
@@ -15,10 +15,10 @@ import uk.gov.logging.api.analytics.logging.AnalyticsLogger
 import uk.gov.logging.impl.AndroidLogger
 import uk.gov.logging.impl.CrashlyticsLogger
 import uk.gov.logging.impl.analytics.FirebaseAnalyticsLogger
-import uk.gov.logging.api.v2.CrashLogger as CrashLoggerV2
-import uk.gov.logging.api.v2.Logger as LoggerV2
-import uk.gov.logging.impl.v2.AndroidLogger as AndroidLoggerV2
-import uk.gov.logging.impl.v2.CrashlyticsLogger as CrashlyticsLoggerV2
+import uk.gov.logging.impl.v3.LogcatLogger
+import uk.gov.logging.api.v3.Logger as LoggerV3
+import uk.gov.logging.impl.v3.CrashlyticsLogger as CrashlyticsLoggerV3
+import uk.gov.logging.impl.v3.MultiLogger as MultiLoggerV3
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -42,8 +42,6 @@ object AnalyticsModule {
     ): AnalyticsLogger = FirebaseAnalyticsLogger(analytics, logger)
 
     @Provides
-    fun provideCrashlyticsLoggerV2(crashlytics: FirebaseCrashlytics): CrashLoggerV2 = CrashlyticsLoggerV2(crashlytics)
-
-    @Provides
-    fun provideLoggerV2(crashLogger: CrashLoggerV2): LoggerV2 = AndroidLoggerV2(crashLogger)
+    fun provideLoggerV3(crashlytics: FirebaseCrashlytics): LoggerV3 =
+        MultiLoggerV3(CrashlyticsLoggerV3(crashlytics), LogcatLogger)
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
         libs.androidx.navigation.testing,
         libs.androidx.test.orchestrator,
         libs.logging.test,
+        testFixtures(libs.logging.api),
     ).forEach(::testImplementation)
 
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/core/src/main/java/uk/gov/onelogin/core/logging/ErrorKeys.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/logging/ErrorKeys.kt
@@ -4,6 +4,7 @@ import uk.gov.logging.api.v3.Logger
 import uk.gov.logging.api.v3.customkey.CustomKey
 import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
 import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
+import uk.gov.onelogin.core.ui.meta.ExcludeFromJacocoGeneratedReport
 
 object ErrorKeys {
     private const val COMPONENT = "component"
@@ -35,6 +36,7 @@ object ErrorKeys {
     fun actionKey(action: String): CustomKey = CustomKey.StringKey(ErrorKeys.ACTION, action)
 }
 
+@ExcludeFromJacocoGeneratedReport
 @Suppress("UnusedPrivateMember")
 private fun errorKeysSample(logger: Logger) {
     logger.error(

--- a/core/src/main/java/uk/gov/onelogin/core/logging/ErrorKeys.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/logging/ErrorKeys.kt
@@ -1,0 +1,47 @@
+package uk.gov.onelogin.core.logging
+
+import uk.gov.logging.api.v3.Logger
+import uk.gov.logging.api.v3.customkey.CustomKey
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
+
+object ErrorKeys {
+    private const val COMPONENT = "component"
+    private const val ACTION = "action"
+
+    /**
+     * Creates a [CustomKey] representing the software component where an error occurred.
+     * The value is automatically prefixed with "app.".
+     *
+     * @param component the feature or module, e.g. "login", "wallet.store", "tokens.persistent_id"
+     * @sample errorKeysSample
+     */
+    fun componentKey(component: String): CustomKey {
+        assert(component.matches(Regex("^[a-z][a-z._]*$"))) {
+            "component must be snake case with dot separators only (e.g. 'login' or 'wallet.store'), got: $component"
+        }
+        assert(!component.startsWith("app.")) {
+            "component includes the app prefix, unnecessarily: $component"
+        }
+        return CustomKey.StringKey(ErrorKeys.COMPONENT, "app.$component")
+    }
+
+    /**
+     * Creates a [CustomKey] representing the action being attempted when an error occurred.
+     *
+     * @param action what was being attempted, e.g. "Redirect to app", "Get persistent ID"
+     * @sample errorKeysSample
+     */
+    fun actionKey(action: String): CustomKey = CustomKey.StringKey(ErrorKeys.ACTION, action)
+}
+
+@Suppress("UnusedPrivateMember")
+private fun errorKeysSample(logger: Logger) {
+    logger.error(
+        "LoginUseCase",
+        "Failed to redirect to app",
+        Exception("Failed to redirect to app"),
+        componentKey("login"),
+        actionKey("Redirect to app"),
+    )
+}

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImpl.kt
@@ -1,8 +1,8 @@
 package uk.gov.onelogin.core.tokens.domain.retrieve
 
 import uk.gov.android.wallet.sdk.WalletSdk
-import uk.gov.logging.api.v2.Logger
-import uk.gov.logging.api.v2.errorKeys.ErrorKeys
+import uk.gov.logging.api.v3.Logger
+import uk.gov.logging.api.v3.customkey.CustomKey
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 import javax.inject.Inject
 
@@ -43,7 +43,7 @@ class GetPersistentIdImpl
                 this.javaClass.simpleName,
                 errorThrown.message ?: "error",
                 errorThrown,
-                ErrorKeys.StringKey("reason", reason)
+                CustomKey.StringKey("reason", reason),
             )
         }
     }

--- a/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImpl.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImpl.kt
@@ -1,8 +1,10 @@
 package uk.gov.onelogin.core.tokens.domain.retrieve
 
 import uk.gov.android.wallet.sdk.WalletSdk
+import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.v3.Logger
-import uk.gov.logging.api.v3.customkey.CustomKey
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 import javax.inject.Inject
 
@@ -13,37 +15,51 @@ class GetPersistentIdImpl
         val getFromOpenSecureStore: GetFromOpenSecureStore,
         private val walletSdk: WalletSdk,
         private val logger: Logger,
-    ) : GetPersistentId {
+    ) : GetPersistentId,
+        LogTagProvider {
         override suspend fun invoke(): String? {
             val id =
                 getFromOpenSecureStore(AuthTokenStoreKeys.PERSISTENT_ID_KEY)?.get(
                     AuthTokenStoreKeys.PERSISTENT_ID_KEY,
                 )
+
+            // Log an error if the Wallet state is inconsistent with the persistent ID
             try {
                 if (id.isNullOrEmpty() && !walletSdk.isEmpty()) {
-                    val exp = Exception("Wallet is not empty")
-                    val reason = "secure wallet data deleted"
-                    logErrors(exp, reason)
+                    logError(GetPersistentIdException.WalletNotEmpty())
                 }
             } catch (walletError: WalletSdk.WalletSdkError.WalletEmptyCheckFailed) {
-                val reason = walletError.message ?: "could not determine if wallet is empty"
-                logErrors(walletError, reason)
+                logError(GetPersistentIdException.WalletEmptyCheckFailed(walletError))
             } catch (e: Throwable) {
-                val reason = "secure wallet data deleted"
-                logErrors(e, reason)
+                // We don't expect this path to be reachable
+                logError(GetPersistentIdException.WalletEmptyCheckFailed(e))
             }
+
             return id
         }
 
-        private fun logErrors(
-            errorThrown: Throwable,
-            reason: String
-        ) {
+        private fun logError(exception: GetPersistentIdException) =
             logger.error(
-                this.javaClass.simpleName,
-                errorThrown.message ?: "error",
-                errorThrown,
-                CustomKey.StringKey("reason", reason),
+                exception.message,
+                exception,
+                componentKey("tokens.persistent_id"),
+                actionKey("Get persistent ID"),
             )
-        }
     }
+
+internal sealed class GetPersistentIdException(
+    override val message: String,
+    override val cause: Throwable? = null,
+) : RuntimeException() {
+    class WalletEmptyCheckFailed(
+        cause: Throwable
+    ) : GetPersistentIdException(
+            "Wallet SDK failed to check if wallet is empty",
+            cause = cause
+        )
+
+    class WalletNotEmpty :
+        GetPersistentIdException(
+            "No persistent ID but wallet isn't empty"
+        )
+}

--- a/core/src/test/java/uk/gov/onelogin/core/logging/ErrorKeysTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/logging/ErrorKeysTest.kt
@@ -1,0 +1,52 @@
+package uk.gov.onelogin.core.logging
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import uk.gov.logging.api.v3.customkey.CustomKey
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
+
+class ErrorKeysTest {
+    @Test
+    fun `componentKey creates key with app prefix`() {
+        val result = componentKey("login")
+
+        assertEquals(CustomKey.StringKey("component", "app.login"), result)
+    }
+
+    @Test
+    fun `componentKey supports dotted components`() {
+        val result = componentKey("wallet.store")
+
+        assertEquals(CustomKey.StringKey("component", "app.wallet.store"), result)
+    }
+
+    @Test
+    fun `componentKey supports snake case components`() {
+        val result = componentKey("id_check")
+
+        assertEquals(CustomKey.StringKey("component", "app.id_check"), result)
+    }
+
+    @Test
+    fun `componentKey rejects uppercase`() {
+        assertThrows<AssertionError> {
+            componentKey("Login")
+        }
+    }
+
+    @Test
+    fun `componentKey rejects app prefix`() {
+        assertThrows<AssertionError> {
+            componentKey("app.login")
+        }
+    }
+
+    @Test
+    fun `actionKey creates action key`() {
+        val result = actionKey("Redirect to app")
+
+        assertEquals(CustomKey.StringKey("action", "Redirect to app"), result)
+    }
+}

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImplTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImplTest.kt
@@ -10,8 +10,9 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.wallet.sdk.WalletSdk
-import uk.gov.logging.api.v2.Logger
-import uk.gov.logging.api.v2.errorKeys.ErrorKeys
+import uk.gov.logging.api.v3.Logger
+import uk.gov.logging.api.v3.MemorisedLogger
+import uk.gov.logging.api.v3.customkey.CustomKey
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 import uk.gov.onelogin.core.utils.MockitoHelper
 import kotlin.test.assertNull
@@ -22,16 +23,16 @@ class GetPersistentIdImplTest {
 
     private val walletSdk: WalletSdk = mock()
 
-    private val logger: Logger = mock()
+    private val logger: Logger = MemorisedLogger()
 
     private val logTag = "GetPersistentIdImpl"
     private val logMessage = "Wallet is not empty"
 
-    val errorKeysTest = ErrorKeys.StringKey("reason", "secure wallet data deleted")
+    val errorKeysTest = CustomKey.StringKey("reason", "secure wallet data deleted")
 
     val tag = "GetPersistentIdImpl"
     val logMessageWalletError = "java.lang.Exception: could not determine if wallet is empty"
-    val walletErrorErrorKeys = ErrorKeys.StringKey("reason", logMessageWalletError)
+    val walletErrorErrorKeys = CustomKey.StringKey("reason", logMessageWalletError)
 
     private val sut =
         GetPersistentIdImpl(

--- a/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImplTest.kt
+++ b/core/src/test/java/uk/gov/onelogin/core/tokens/domain/retrieve/GetPersistentIdImplTest.kt
@@ -1,18 +1,27 @@
 package uk.gov.onelogin.core.tokens.domain.retrieve
 
 import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.instanceOf
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.android.wallet.sdk.WalletSdk
-import uk.gov.logging.api.v3.Logger
 import uk.gov.logging.api.v3.MemorisedLogger
-import uk.gov.logging.api.v3.customkey.CustomKey
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasCustomKeys
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasException
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasLogEntry
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasMessage
+import uk.gov.logging.api.v3.matchers.MemorisedLoggerMatchers.hasSize
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
 import uk.gov.onelogin.core.tokens.utils.AuthTokenStoreKeys
 import uk.gov.onelogin.core.utils.MockitoHelper
 import kotlin.test.assertNull
@@ -20,19 +29,12 @@ import kotlin.test.assertNull
 class GetPersistentIdImplTest {
     private val expectedPersistentId = "cc893ece-b6bd-444d-9bb4-dec6f5778e50"
     private val mockGetFromOpenSecureStore: GetFromOpenSecureStore = mock()
-
     private val walletSdk: WalletSdk = mock()
 
-    private val logger: Logger = MemorisedLogger()
+    private val logger = MemorisedLogger()
 
-    private val logTag = "GetPersistentIdImpl"
-    private val logMessage = "Wallet is not empty"
-
-    val errorKeysTest = CustomKey.StringKey("reason", "secure wallet data deleted")
-
-    val tag = "GetPersistentIdImpl"
-    val logMessageWalletError = "java.lang.Exception: could not determine if wallet is empty"
-    val walletErrorErrorKeys = CustomKey.StringKey("reason", logMessageWalletError)
+    private val componentKey = componentKey("tokens.persistent_id")
+    private val actionKey = actionKey("Get persistent ID")
 
     private val sut =
         GetPersistentIdImpl(
@@ -93,17 +95,31 @@ class GetPersistentIdImplTest {
             )
 
             sut.invoke()
-            verify(logger).error(
-                eq(logTag),
-                eq(logMessage),
-                any(),
-                eq(errorKeysTest)
+
+            assertThat(logger, hasSize(1))
+            assertThat(
+                logger,
+                hasLogEntry(
+                    hasItem(
+                        allOf(
+                            hasMessage("No persistent ID but wallet isn't empty"),
+                            hasException(instanceOf(GetPersistentIdException.WalletNotEmpty::class.java)),
+                            hasCustomKeys(
+                                contains(
+                                    equalTo(componentKey),
+                                    equalTo(actionKey)
+                                )
+                            ),
+                        )
+                    )
+                )
             )
         }
     }
 
+    // We don't expect this scenario to occur in practice
     @Test
-    fun `check if logger logs when check if wallet is empty throws an exception`() {
+    fun `check if logger logs when check if wallet is empty throws an unexpected exception`() {
         runTest {
             val expected = Throwable("Wallet is not empty")
             whenever(
@@ -118,30 +134,29 @@ class GetPersistentIdImplTest {
 
             sut.invoke()
 
-            verify(logger).error(
-                eq(logTag),
-                eq(logMessage),
-                any(),
-                eq(errorKeysTest)
+            assertThat(logger, hasSize(1))
+            assertThat(
+                logger,
+                hasLogEntry(
+                    hasItem(
+                        allOf(
+                            hasMessage("Wallet SDK failed to check if wallet is empty"),
+                            hasException(
+                                instanceOf(
+                                    GetPersistentIdException.WalletEmptyCheckFailed::class.java
+                                )
+                            ),
+                            hasCustomKeys(
+                                contains(
+                                    equalTo(componentKey),
+                                    equalTo(actionKey)
+                                )
+                            ),
+                        )
+                    )
+                )
             )
         }
-    }
-
-    @Test
-    fun `check if logger logs when get wallet throws exception`() {
-        val expected = Error("could not determine if wallet is empty")
-        whenever(
-            walletSdk.isEmpty()
-        ).thenThrow(
-            expected
-        )
-        logger.error(tag = logTag, message = logMessage, throwable = expected, errorKeysTest)
-        verify(logger).error(
-            eq(logTag),
-            eq(logMessage),
-            any(),
-            eq(errorKeysTest)
-        )
     }
 
     @Test
@@ -160,11 +175,28 @@ class GetPersistentIdImplTest {
             }.`when`(walletSdk).isEmpty()
 
             sut.invoke()
-            verify(logger).error(
-                eq(tag),
-                eq(logMessageWalletError),
-                eq(expected),
-                eq(walletErrorErrorKeys)
+
+            assertThat(logger, hasSize(1))
+            assertThat(
+                logger,
+                hasLogEntry(
+                    hasItem(
+                        allOf(
+                            hasMessage("Wallet SDK failed to check if wallet is empty"),
+                            hasException(
+                                instanceOf(
+                                    GetPersistentIdException.WalletEmptyCheckFailed::class.java
+                                )
+                            ),
+                            hasCustomKeys(
+                                contains(
+                                    equalTo(componentKey),
+                                    equalTo(actionKey)
+                                )
+                            ),
+                        )
+                    )
+                )
             )
         }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ firebaseBom = "34.11.0"
 crashlytics = "3.0.3"
 classgraph = "4.8.179"
 govuk-ui = "16.10.0"
-govuk-logging = "0.40.2"
+govuk-logging = "0.40.4"
 compose-runtime = "1.9.4"
 auth = "3.3.0"
 wallet = "v2.292.1"
@@ -140,6 +140,7 @@ authentication = { group = "uk.gov.android.authentication", name = "app", versio
 localauth = { group = "uk.gov.android.authentication", name = "localauth", version.ref = "auth" }
 secure-store = { group = "uk.gov.securestore", name = "app", version.ref = "secureStore" }
 network = { group = "uk.gov.android", name = "network", version.ref = "network" }
+logging-api = { group = "uk.gov.logging", name = "logging-api", version.ref = "govuk-logging" }
 logging-impl = { group = "uk.gov.logging", name = "logging-impl", version.ref = "govuk-logging" }
 logging-test = { group = "uk.gov.logging", name = "logging-testdouble", version.ref = "govuk-logging" }
 


### PR DESCRIPTION
## Changes

- Replace all instances of Logger V2 with Logger V3
- Add convenience functions for creating `component` and `action` error keys (Firebase custom keys)
- Update usage of custom error keys in `GetPersistentIdImpl`
- Refactor error logging in `GetPersistentIdImpl`

## Out of scope

- Replace all instances of Logger V1 with Logger V3:
  - #872 


## Context

DCMAW-20625