### PR TITLE
feat: Enhance logs for AppInfo errors returned for /appInfo API calls

### DIFF
--- a/core/src/main/java/uk/gov/onelogin/core/tokens/data/ApiInfoException.kt
+++ b/core/src/main/java/uk/gov/onelogin/core/tokens/data/ApiInfoException.kt
@@ -1,5 +1,5 @@
 package uk.gov.onelogin.core.tokens.data
 
 data class ApiInfoException(
-    val exception: Exception,
+    val exception: Throwable,
 ) : Exception(exception.message)

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoRemoteSourceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoRemoteSourceImpl.kt
@@ -19,6 +19,7 @@ class AppInfoRemoteSourceImpl
                         result.response as AppInfoData,
                     )
                 is ApiResponse.Offline -> AppInfoRemoteState.Offline
+                is ApiResponse.Failure -> AppInfoRemoteState.Failure("Status: ${result.status}", result.error)
                 else -> AppInfoRemoteState.Failure(APP_INFO_REMOTE_SOURCE_ERROR)
             }
 

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoRemoteSourceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/AppInfoRemoteSourceImpl.kt
@@ -20,7 +20,12 @@ class AppInfoRemoteSourceImpl
                     )
                 is ApiResponse.Offline -> AppInfoRemoteState.Offline
                 is ApiResponse.Failure -> AppInfoRemoteState.Failure("Status: ${result.status}", result.error)
-                else -> AppInfoRemoteState.Failure(APP_INFO_REMOTE_SOURCE_ERROR)
+                // The Loading response type is never actually returned (due to be fixed in DCMAW-20185)
+                ApiResponse.Loading ->
+                    AppInfoRemoteState.Failure(
+                        APP_INFO_REMOTE_SOURCE_ERROR,
+                        error = Exception("Unexpected Loading API response"),
+                    )
             }
 
         companion object {

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/model/AppInfoRemoteState.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/model/AppInfoRemoteState.kt
@@ -7,6 +7,7 @@ sealed class AppInfoRemoteState {
 
     data class Failure(
         val reason: String,
+        val error: Throwable? = null,
     ) : AppInfoRemoteState()
 
     data object Offline : AppInfoRemoteState()

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/data/model/AppInfoRemoteState.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/data/model/AppInfoRemoteState.kt
@@ -7,7 +7,7 @@ sealed class AppInfoRemoteState {
 
     data class Failure(
         val reason: String,
-        val error: Throwable? = null,
+        val error: Throwable,
     ) : AppInfoRemoteState()
 
     data object Offline : AppInfoRemoteState()

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
@@ -1,6 +1,9 @@
 package uk.gov.onelogin.features.appinfo.domain
 
+import uk.gov.logging.api.LogTagProvider
 import uk.gov.logging.api.v3.Logger
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
 import uk.gov.onelogin.core.tokens.data.ApiInfoException
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoLocalState
 import uk.gov.onelogin.features.appinfo.data.model.AppInfoRemoteState
@@ -16,7 +19,8 @@ class AppInfoServiceImpl
         private val appVersionCheck: AppVersionCheck,
         private val featureFlagSetter: FeatureFlagSetter,
         private val logger: Logger,
-    ) : AppInfoService {
+    ) : AppInfoService,
+        LogTagProvider {
         override suspend fun get(): AppInfoServiceState =
             when (val remoteResult = remoteSource.get()) {
                 is AppInfoRemoteState.Success -> {
@@ -25,11 +29,15 @@ class AppInfoServiceImpl
                 }
                 AppInfoRemoteState.Offline -> useLocalSource(AppInfoServiceState.Offline)
                 is AppInfoRemoteState.Failure -> {
-                    val apiException = ApiInfoException(Exception(remoteResult.reason))
+                    val apiException =
+                        remoteResult.error?.let {
+                            ApiInfoException(it)
+                        } ?: ApiInfoException(Exception(remoteResult.reason))
                     logger.error(
-                        apiException::class.simpleName.toString(),
                         remoteResult.reason,
                         apiException,
+                        componentKey(COMPONENT),
+                        actionKey(ACTION),
                     )
                     useLocalSource(AppInfoServiceState.Unavailable)
                 }
@@ -49,5 +57,10 @@ class AppInfoServiceImpl
             } else {
                 fallback
             }
+        }
+
+        companion object {
+            internal const val COMPONENT = "app_info"
+            internal const val ACTION = "Get remote app info"
         }
     }

--- a/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/appinfo/domain/AppInfoServiceImpl.kt
@@ -29,10 +29,7 @@ class AppInfoServiceImpl
                 }
                 AppInfoRemoteState.Offline -> useLocalSource(AppInfoServiceState.Offline)
                 is AppInfoRemoteState.Failure -> {
-                    val apiException =
-                        remoteResult.error?.let {
-                            ApiInfoException(it)
-                        } ?: ApiInfoException(Exception(remoteResult.reason))
+                    val apiException = ApiInfoException(remoteResult.error)
                     logger.error(
                         remoteResult.reason,
                         apiException,

--- a/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoRemoteSourceImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoRemoteSourceImplTest.kt
@@ -50,7 +50,7 @@ class AppInfoRemoteSourceImplTest {
             whenever(appInfoApi.callApi()).thenReturn(ApiResponse.Failure(500, exp))
             val result = sut.get()
             assertEquals(
-                AppInfoRemoteState.Failure(AppInfoRemoteSourceImpl.Companion.APP_INFO_REMOTE_SOURCE_ERROR),
+                AppInfoRemoteState.Failure("Status: 500", exp),
                 result
             )
         }

--- a/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoServiceImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoServiceImplTest.kt
@@ -3,8 +3,10 @@ package uk.gov.onelogin.features.unit.appinfo.data
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItem
-import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -13,10 +15,13 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.logging.api.v3.LogLevel
 import uk.gov.logging.api.v3.MemorisedLogger
+import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasCustomKeys
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasException
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.hasMessage
 import uk.gov.logging.api.v3.matchers.LogEntryMatchers.isLogLevel
 import uk.gov.logging.api.v3.matchers.MemorisedLoggerMatchers.hasSize
+import uk.gov.onelogin.core.logging.ErrorKeys.actionKey
+import uk.gov.onelogin.core.logging.ErrorKeys.componentKey
 import uk.gov.onelogin.core.tokens.data.ApiInfoException
 import uk.gov.onelogin.features.TestUtils
 import uk.gov.onelogin.features.appinfo.data.AppInfoLocalSourceImpl
@@ -42,6 +47,8 @@ class AppInfoServiceImplTest {
     private val dataAppUnavailable = TestUtils.appInfoDataAppUnavailable
     private val localSourceErrorMsg = AppInfoLocalSourceImpl.Companion.APP_INFO_LOCAL_SOURCE_ERROR
     private val remoteSourceErrorMsg = AppInfoRemoteSourceImpl.Companion.APP_INFO_REMOTE_SOURCE_ERROR
+    private val errorKeyComponent = componentKey("app_info")
+    private val errorKeyActionGetRemote = actionKey("Get remote app info")
 
     private lateinit var sut: AppInfoService
 
@@ -100,12 +107,13 @@ class AppInfoServiceImplTest {
         }
 
     @Test
-    fun `failed remote - successful local retrieval`() =
+    fun `failed remote with error - successful local retrieval`() =
         runTest {
+            val err = ApiInfoException(Exception(remoteSourceErrorMsg))
             logger = MemorisedLogger()
             setup()
             whenever(remoteSource.get()).thenReturn(
-                AppInfoRemoteState.Failure(remoteSourceErrorMsg)
+                AppInfoRemoteState.Failure(err.message!!, err.exception)
             )
             whenever(localSource.get()).thenReturn(AppInfoLocalState.Success(data))
             whenever(appVersionCheck.compareVersions(eq(data)))
@@ -118,7 +126,46 @@ class AppInfoServiceImplTest {
                     allOf(
                         isLogLevel(LogLevel.Error),
                         hasMessage(remoteSourceErrorMsg),
-                        hasException(instanceOf(ApiInfoException::class.java))
+                        hasException(equalTo(err)),
+                        hasCustomKeys(
+                            contains(
+                                equalTo(errorKeyComponent),
+                                equalTo(errorKeyActionGetRemote)
+                            )
+                        )
+                    )
+                )
+            )
+            verify(featureFlagSetter).setFromAppInfo(data.apps.android)
+        }
+
+    @Test
+    fun `failed remote without error - successful local retrieval`() =
+        runTest {
+            val err = ApiInfoException(Exception(remoteSourceErrorMsg))
+            logger = MemorisedLogger()
+            setup()
+            whenever(remoteSource.get()).thenReturn(
+                AppInfoRemoteState.Failure(err.message!!)
+            )
+            whenever(localSource.get()).thenReturn(AppInfoLocalState.Success(data))
+            whenever(appVersionCheck.compareVersions(eq(data)))
+                .thenReturn(AppInfoServiceState.Successful(data))
+            val result = sut.get()
+            assertEquals(AppInfoServiceState.Successful(data), result)
+            assertThat(
+                logger,
+                hasItem(
+                    allOf(
+                        isLogLevel(LogLevel.Error),
+                        hasMessage(remoteSourceErrorMsg),
+                        not(hasException(equalTo(err))),
+                        hasCustomKeys(
+                            contains(
+                                equalTo(errorKeyComponent),
+                                equalTo(errorKeyActionGetRemote)
+                            )
+                        )
                     )
                 )
             )
@@ -128,10 +175,12 @@ class AppInfoServiceImplTest {
     @Test
     fun `failed remote and local retrieval`() =
         runTest {
+            val err = Exception(remoteSourceErrorMsg)
+            val wrappedException = ApiInfoException(err)
             logger = MemorisedLogger()
             setup()
             whenever(remoteSource.get()).thenReturn(
-                AppInfoRemoteState.Failure(remoteSourceErrorMsg)
+                AppInfoRemoteState.Failure(err.message!!, err)
             )
             whenever(localSource.get()).thenReturn(AppInfoLocalState.Failure(localSourceErrorMsg))
             val result = sut.get()
@@ -142,7 +191,13 @@ class AppInfoServiceImplTest {
                     allOf(
                         isLogLevel(LogLevel.Error),
                         hasMessage(remoteSourceErrorMsg),
-                        hasException(instanceOf(ApiInfoException::class.java))
+                        hasException(equalTo(wrappedException)),
+                        hasCustomKeys(
+                            contains(
+                                equalTo(errorKeyComponent),
+                                equalTo(errorKeyActionGetRemote)
+                            )
+                        )
                     )
                 )
             )

--- a/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoServiceImplTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/appinfo/data/AppInfoServiceImplTest.kt
@@ -140,39 +140,6 @@ class AppInfoServiceImplTest {
         }
 
     @Test
-    fun `failed remote without error - successful local retrieval`() =
-        runTest {
-            val err = ApiInfoException(Exception(remoteSourceErrorMsg))
-            logger = MemorisedLogger()
-            setup()
-            whenever(remoteSource.get()).thenReturn(
-                AppInfoRemoteState.Failure(err.message!!)
-            )
-            whenever(localSource.get()).thenReturn(AppInfoLocalState.Success(data))
-            whenever(appVersionCheck.compareVersions(eq(data)))
-                .thenReturn(AppInfoServiceState.Successful(data))
-            val result = sut.get()
-            assertEquals(AppInfoServiceState.Successful(data), result)
-            assertThat(
-                logger,
-                hasItem(
-                    allOf(
-                        isLogLevel(LogLevel.Error),
-                        hasMessage(remoteSourceErrorMsg),
-                        not(hasException(equalTo(err))),
-                        hasCustomKeys(
-                            contains(
-                                equalTo(errorKeyComponent),
-                                equalTo(errorKeyActionGetRemote)
-                            )
-                        )
-                    )
-                )
-            )
-            verify(featureFlagSetter).setFromAppInfo(data.apps.android)
-        }
-
-    @Test
     fun `failed remote and local retrieval`() =
         runTest {
             val err = Exception(remoteSourceErrorMsg)


### PR DESCRIPTION
## Changes

- Log custom error keys for /appInfo API errors

## Context

Enables better filtering in Firebase Crashlytics.

This PR supersedes #849, resolving PR comments.

DCMAW-20191