### PR TITLE
ci: Fix build and staging app deployment workflow (develop branch)

### DIFF
--- a/.github/workflows/deploy_develop.yml
+++ b/.github/workflows/deploy_develop.yml
@@ -1,5 +1,5 @@
 # When making structure changes to the workflow, please ensure the quality-gate.manifest.json is updated accordingly to reflect this.
-name: On Branch Push (develop)
+name: Deploy Build/Staging (develop)
 
 on:
   workflow_run:

--- a/.github/workflows/on_push_develop.yml
+++ b/.github/workflows/on_push_develop.yml
@@ -6,9 +6,6 @@ on:
     workflows: [ Run checks (tests and style checks) ]
     branches: [ develop ]
     types: [ completed ]
-  push:
-    branches:
-      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Context

#819 updated the build and staging app deployment workflow to be triggered after the new test/check workflow completes.

However, the existing trigger wasn't removed. The deployment workflow is still triggered immediately on push but can't succeed as it expects the context available from the `workflow_run` trigger.

DCMAW-20463

## Changes

- Remove the `push` trigger from the build/staging app deployment workflow