### PR TITLE
refactor: DCMAW-20188 Use Hilt to instantiate StsAuthenticationProvider

### DIFF
--- a/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/gov/onelogin/MainActivityViewModel.kt
@@ -1,54 +1,19 @@
 package uk.gov.onelogin
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
+import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.client.GenericHttpClient
-import uk.gov.android.onelogin.core.R
-import uk.gov.logging.api.v3.Logger
-import uk.gov.onelogin.core.navigation.domain.Navigator
-import uk.gov.onelogin.core.tokens.data.TokenRepository
-import uk.gov.onelogin.core.tokens.domain.expirychecks.IsTokenExpired
-import uk.gov.onelogin.core.utils.AccessToken
-import uk.gov.onelogin.core.utils.ActivityProvider
-import uk.gov.onelogin.features.login.domain.refresh.RefreshExchange
-import uk.gov.onelogin.features.network.provider.StsAuthenticationProvider
-import uk.gov.onelogin.features.signout.domain.SignOutUseCase
 import javax.inject.Inject
 
-@Suppress("LongParameterList")
 @HiltViewModel
 class MainActivityViewModel
     @Inject
     constructor(
-        private val activityProvider: ActivityProvider,
-        @param:ApplicationContext
-        private val context: Context,
         private val genericHttpClient: GenericHttpClient,
-        private val tokenRepository: TokenRepository,
-        @param:AccessToken
-        private val isAccessTokenExpired: IsTokenExpired,
-        private val navigator: Navigator,
-        private val refreshExchange: RefreshExchange,
-        private val signOutUseCase: SignOutUseCase,
-        private val logger: Logger
+        private val authenticationProvider: AuthenticationProvider,
     ) : ViewModel() {
         fun setHttpClientAuthProvider() {
-            val endpoint = context.getString(R.string.tokenExchangeEndpoint)
-            val url = context.getString(R.string.stsUrl, endpoint)
-            val provider =
-                StsAuthenticationProvider(
-                    activityProvider,
-                    url,
-                    tokenRepository,
-                    isAccessTokenExpired,
-                    genericHttpClient,
-                    navigator,
-                    refreshExchange,
-                    signOutUseCase,
-                    logger
-                )
-            genericHttpClient.setAuthenticationProvider(provider)
+            genericHttpClient.setAuthenticationProvider(authenticationProvider)
         }
     }

--- a/app/src/main/java/uk/gov/onelogin/network/AuthenticationProviderModule.kt
+++ b/app/src/main/java/uk/gov/onelogin/network/AuthenticationProviderModule.kt
@@ -1,0 +1,55 @@
+package uk.gov.onelogin.network
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import uk.gov.android.network.auth.AuthenticationProvider
+import uk.gov.android.network.client.GenericHttpClient
+import uk.gov.android.onelogin.core.R
+import uk.gov.logging.api.v3.Logger
+import uk.gov.onelogin.core.navigation.domain.Navigator
+import uk.gov.onelogin.core.tokens.data.TokenRepository
+import uk.gov.onelogin.core.tokens.domain.expirychecks.IsTokenExpired
+import uk.gov.onelogin.core.utils.AccessToken
+import uk.gov.onelogin.core.utils.ActivityProvider
+import uk.gov.onelogin.features.login.domain.refresh.RefreshExchange
+import uk.gov.onelogin.features.network.provider.StsAuthenticationProvider
+import uk.gov.onelogin.features.signout.domain.SignOutUseCase
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object AuthenticationProviderModule {
+    @Suppress("LongParameterList")
+    @Provides
+    fun provideAuthenticationProvider(
+        activityProvider: ActivityProvider,
+        @ApplicationContext context: Context,
+        genericHttpClient: GenericHttpClient,
+        tokenRepository: TokenRepository,
+        @AccessToken isAccessTokenExpired: IsTokenExpired,
+        navigator: Navigator,
+        refreshExchange: RefreshExchange,
+        signOutUseCase: SignOutUseCase,
+        logger: Logger,
+    ): AuthenticationProvider {
+        val stsUrl =
+            context.getString(
+                R.string.stsUrl,
+                context.getString(R.string.tokenExchangeEndpoint),
+            )
+        return StsAuthenticationProvider(
+            activityProvider,
+            stsUrl,
+            tokenRepository,
+            isAccessTokenExpired,
+            genericHttpClient,
+            navigator,
+            refreshExchange,
+            signOutUseCase,
+            logger,
+        )
+    }
+}

--- a/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
+++ b/app/src/test/java/uk/gov/onelogin/MainActivityViewModelTest.kt
@@ -1,49 +1,20 @@
 package uk.gov.onelogin
 
-import android.content.Context
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
+import uk.gov.android.network.auth.AuthenticationProvider
 import uk.gov.android.network.client.GenericHttpClient
-import uk.gov.logging.api.v3.MemorisedLogger
-import uk.gov.onelogin.core.navigation.domain.Navigator
-import uk.gov.onelogin.core.tokens.data.TokenRepository
-import uk.gov.onelogin.core.tokens.domain.expirychecks.IsTokenExpired
-import uk.gov.onelogin.core.utils.ActivityProvider
-import uk.gov.onelogin.features.login.domain.refresh.RefreshExchange
-import uk.gov.onelogin.features.signout.domain.SignOutUseCase
 
 class MainActivityViewModelTest {
-    private var activityProvider: ActivityProvider = mock()
-    private var context: Context = mock()
-    private var genericHttpClient: GenericHttpClient = mock()
-    private var tokenRepository: TokenRepository = mock()
-    private var isAccessTokenExpired: IsTokenExpired = mock()
-    private var navigator: Navigator = mock()
-    private var refreshExchange: RefreshExchange = mock()
-    private var signOutUseCase: SignOutUseCase = mock()
-    private var logger = MemorisedLogger()
-    private var vm: MainActivityViewModel =
-        MainActivityViewModel(
-            activityProvider,
-            context,
-            genericHttpClient,
-            tokenRepository,
-            isAccessTokenExpired,
-            navigator,
-            refreshExchange,
-            signOutUseCase,
-            logger
-        )
+    private val genericHttpClient: GenericHttpClient = mock()
+    private val authenticationProvider: AuthenticationProvider = mock()
+    private val vm = MainActivityViewModel(genericHttpClient, authenticationProvider)
 
     @Test
-    fun `test sts provider setter`() {
-        whenever(context.getString(any())).thenReturn("")
-        whenever(context.getString(any(), any<String>())).thenReturn("")
+    fun `setHttpClientAuthProvider sets the authentication provider on the http client`() {
         vm.setHttpClientAuthProvider()
 
-        verify(genericHttpClient).setAuthenticationProvider(any())
+        verify(genericHttpClient).setAuthenticationProvider(authenticationProvider)
     }
 }


### PR DESCRIPTION
## Context

- Enables more providers similar to `AuthenticationProvider` to added to the HttpClient without bloating the `MainActivityViewModel`
- Keeps dependency injection logic in Hilt modules where it belongs

To be followed by
- #888

DCMAW-20188