### PR TITLE
ci: DCMAW-17480 Add cocogitto configuration

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,0 +1,10 @@
+branch_whitelist = ["main"]
+disable_bump_commit = true
+ignore_merge_commits = true
+tag_prefix = "v"
+
+[changelog]
+template = "remote"
+remote = "github.com"
+repository = "mobile-android-one-login-app"
+owner = "govuk-one-login"


### PR DESCRIPTION
## Context

Enables Cocogitto to generate a changelog from the latest tag properly.

Currently `cog changelog --at v$(cog -v get-version)` is failing with an error:

```
Error: invalid commit range pattern: `v1.7.0`
```

This is because we haven't configured Cocogitto with the version tag prefix (`v`) so `cog get-version` outputs `1.7.0` which is an older tag without the prefix.

DCMAW-17480

## Changes

Add Cocogitto `cog.toml` configuration for this project.

## Evidence

### Before

```sh
$ cog -v get-version

1.7.0

$ cog changelog --at v$(cog -v get-version)

Error: invalid commit range pattern: `v1.7.0`
```

### After

```sh
$ cog -v get-version

1.21.2

$ cog changelog --at v$(cog -v get-version)

## [[v1.22.0](https://github.com/govuk-one-login/mobile-android-networking/compare/d511aeb2eacc92aec809b57fb2c96aab48bd190a..v1.22.0)](https://github.com/govuk-one-login/mobile-android-networking/compare/d511aeb2eacc92aec809b57fb2c96aab48bd190a..v1.22.0) - 2026-06-24
#### Bug Fixes
... etc
```

