### PR TITLE
fix: include implementation for bouncycastle minimum version requirement

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,6 +147,9 @@ subprojects {
                 add("testImplementation", libs.bouncycastle.bcprov.get()) {
                     because("previous versions have a CVE vulnerability (introduced transitively via robolectric)")
                 }
+                add("implementation", libs.bouncycastle.bcprov.get()) {
+                    because("previous versions have a CVE vulnerability")
+                }
             }
         }
     }


### PR DESCRIPTION
Another small fix here to attempt to fix this other critical vulnerability: https://github.com/govuk-one-login/mobile-android-one-login-app/security/dependabot/72