### PR TITLE
chore: DCMAW-21789 Temporarily opt-out of predictive back navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:name="uk.gov.onelogin.OneLoginApplication"
         android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="false"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/one_login_app_name"
@@ -21,7 +22,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.OneLogin"
         tools:replace="android:theme"
-        tools:targetApi="31">
+        tools:targetApi="33">
         <activity
             android:name="uk.gov.onelogin.MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Context

Opt out of predictive back navigation while One Login app, CRI Orchestrator SDK and Wallet SDK migrate to supported navigation APIs.

DCMAW-21789