### PR TITLE
build: Improve noisy error logs when gradle properties are missing

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,12 +48,11 @@ fun fetchGithubCredentials(): Pair<String, String> {
 
     return try {
         gprUser.get() to gprToken.get()
-    } catch (exception: MissingValueException) {
+    } catch (_: MissingValueException) {
         logger.warn(
             "Could not find 'Github Package Registry' properties. Refer to the proceeding " +
                 "location for instructions:\n\n" +
                 "${rootDir.path}/docs/developerSetup/github-authentication.md\n",
-            exception
         )
 
         System.getenv("USERNAME") to System.getenv("TOKEN")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,21 +47,21 @@ fun fetchGithubCredentials(): Pair<String, String> =
     fetchGithubCredentialsFromEnvironment()
 
 fun fetchGithubCredentialsFromProperties(): Pair<String, String>? {
-    fun tryGetProperty(propertyName: String): String? = try {
-        providers.gradleProperty(propertyName).get()
-    } catch (_: MissingValueException) {
-        logger.warn(
-            "Could not find 'Github Package Registry' property: $propertyName. Refer to the proceeding " +
-                    "location for instructions:\n\n" +
-                    "${rootDir.path}/docs/developerSetup/github-authentication.md\n",
-        )
-        null
-    }
-
-    val gprUser = tryGetProperty("gpr.user") ?: return null
-    val gprToken = tryGetProperty("gpr.token") ?: return null
+    val gprUser = getGithubCredentialsProperty("gpr.user") ?: return null
+    val gprToken = getGithubCredentialsProperty("gpr.token") ?: return null
 
     return gprUser to gprToken
+}
+
+fun getGithubCredentialsProperty(propertyName: String): String? = try {
+    providers.gradleProperty(propertyName).get()
+} catch (_: MissingValueException) {
+    logger.warn(
+        "Could not find 'Github Package Registry' property: $propertyName. Refer to the proceeding " +
+                "location for instructions:\n\n" +
+                "${rootDir.path}/docs/developerSetup/github-authentication.md\n",
+    )
+    null
 }
 
 fun fetchGithubCredentialsFromEnvironment(): Pair<String, String> =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,22 +42,30 @@ fun setupGithubCredentials(): MavenArtifactRepository.() -> Unit =
         }
     }
 
-fun fetchGithubCredentials(): Pair<String, String> {
-    val gprUser = providers.gradleProperty("gpr.user")
-    val gprToken = providers.gradleProperty("gpr.token")
+fun fetchGithubCredentials(): Pair<String, String> =
+    fetchGithubCredentialsFromProperties() ?:
+    fetchGithubCredentialsFromEnvironment()
 
-    return try {
-        gprUser.get() to gprToken.get()
+fun fetchGithubCredentialsFromProperties(): Pair<String, String>? {
+    fun tryGetProperty(propertyName: String): String? = try {
+        providers.gradleProperty(propertyName).get()
     } catch (_: MissingValueException) {
         logger.warn(
-            "Could not find 'Github Package Registry' properties. Refer to the proceeding " +
-                "location for instructions:\n\n" +
-                "${rootDir.path}/docs/developerSetup/github-authentication.md\n",
+            "Could not find 'Github Package Registry' property: $propertyName. Refer to the proceeding " +
+                    "location for instructions:\n\n" +
+                    "${rootDir.path}/docs/developerSetup/github-authentication.md\n",
         )
-
-        System.getenv("USERNAME") to System.getenv("TOKEN")
+        null
     }
+
+    val gprUser = tryGetProperty("gpr.user") ?: return null
+    val gprToken = tryGetProperty("gpr.token") ?: return null
+
+    return gprUser to gprToken
 }
+
+fun fetchGithubCredentialsFromEnvironment(): Pair<String, String> =
+    System.getenv("USERNAME") to System.getenv("TOKEN")
 
 // https://docs.gradle.org/8.0/userguide/kotlin_dsl.html#type-safe-accessors
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Context

Makes it easier to find errors in CI build logs.