### PR TITLE
ci: DCMAW-21639 Delay version code generation until deployment

### DIFF
--- a/.github/workflows/on_push_release.yml
+++ b/.github/workflows/on_push_release.yml
@@ -12,10 +12,9 @@ concurrency:
 
 jobs:
   set-up:
-    name: Set-up and generate version name and version code
+    name: Set-up and generate version name
     runs-on: ubuntu-24.04
     outputs:
-      version-code: ${{ steps.version-code.outputs.version-code }}
       version-name: ${{ steps.next-version.outputs.next-version }}
 
     steps:
@@ -31,10 +30,6 @@ jobs:
         uses: ./config/actions/get-latest-tag
         with:
           pattern: 'v*'
-
-      - name: Generate version code
-        id: version-code
-        uses: ./mobile-android-pipelines/actions/generate-version-code
 
       - name: Get next version from branch
         id: next-version
@@ -94,6 +89,10 @@ jobs:
         with:
           actions-role-arn: ${{ secrets.GITHUBRUNNER_EC2_ACTIONS_ROLE_ARN }}
 
+      - name: Generate version code
+        id: version-code
+        uses: ./mobile-android-pipelines/actions/generate-version-code
+
       - name: Bundle release
         id: bundle-release
         uses: ./config/actions/gradle-assemble-and-bundle
@@ -103,7 +102,7 @@ jobs:
           flavors: ${{ matrix.environment }}
           github-actor: ${{ secrets.GITHUB_ACTOR }}
           module-fetch-token-username: ${{ secrets.MODULE_FETCH_TOKEN_USERNAME }}
-          version-code: ${{ needs.set-up.outputs.version-code }}
+          version-code: ${{ steps.version-code.outputs.version-code }}
           version-name: ${{ needs.set-up.outputs.version-name }}
           app-check-token: ${{ secrets.BUILD_APPCHECK_DEBUG_TOKEN }}
           keystore-file-path: ${{ steps.retrieve-secrets.outputs.keystore-file-path }}
@@ -117,7 +116,7 @@ jobs:
         uses: ./config/actions/git-tag-bundles
         with:
           aab-paths: ${{ steps.bundle-release.outputs.aab-paths }}
-          version-code: ${{ needs.set-up.outputs.version-code }}
+          version-code: ${{ steps.version-code.outputs.version-code }}
           version-name: ${{ needs.set-up.outputs.version-name }}
 
       - name: Clean workspace


### PR DESCRIPTION
## Context

Usually, the jobs in the `on_push_release` workflow wait for a while before being deployed. However, the versioning job runs immediately upon raising the PR. As the version code is based on the current timestamp, it can go stale as soon as a new build is published by a different branch.

This PR intends to reduce the risk of that happening by delaying the version code generation, moving it into the same job that deploys the app builds.