### PR TITLE
fix: DCMAW-22138 Workaround for crash occurring when wallet store ID initialisation is cancelled

### DIFF
--- a/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreen.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreen.kt
@@ -3,22 +3,24 @@ package uk.gov.onelogin.features.wallet.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.key
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.gov.onelogin.core.ui.pages.loading.LoadingScreen
+import uk.gov.onelogin.core.ui.pages.loading.LoadingScreenAnalyticsViewModel
 
 @Composable
 fun WalletScreen(
     deepLinkRoute: Boolean,
     setDisplayContentAsFullScreen: (Boolean) -> Unit,
     viewModel: WalletScreenViewModel = hiltViewModel(),
+    loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel = hiltViewModel(),
 ) {
 
 
     key(deepLinkRoute) {
         when (val state = viewModel.state.collectAsState().value) {
             is WalletScreenState.Loading -> {
-                LoadingScreen { }
+                LoadingScreen(analyticsViewModel = loadingAnalyticsViewModel) { }
             }
             is WalletScreenState.Display ->
                 state.walletAppDisplayer.WalletApp()

--- a/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModel.kt
+++ b/features/src/main/java/uk/gov/onelogin/features/wallet/ui/WalletScreenViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import uk.gov.android.wallet.sdk.WalletSdk
 import uk.gov.onelogin.core.tokens.domain.retrieve.GetWalletStoreId
 import uk.gov.onelogin.features.login.domain.validateWalletStoreId.ValidateWalletStoreId
@@ -58,6 +59,10 @@ class WalletScreenViewModel
      */
     private suspend fun prepareWalletSdkForDisplay(): WalletAppDisplayer {
         val walletStoreId = getWalletStoreId()
+
+        // Workaround for DCMAW-22138
+        // Check for coroutine cancellation here because the secure store doesn't propagate it (DCMAW-22143)
+        yield()
 
         requireNotNull(walletStoreId) {
             "Wallet Store ID must not be null. This is guaranteed by ValidateWalletStoreId"

--- a/features/src/test/java/uk/gov/onelogin/features/component/wallet/WalletScreenTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/component/wallet/WalletScreenTest.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.android.wallet.sdk.WalletSdk
 import uk.gov.onelogin.core.tokens.domain.retrieve.GetWalletStoreId
+import uk.gov.onelogin.core.ui.pages.loading.LoadingScreenAnalyticsViewModel
 import uk.gov.onelogin.core.ui.wallet.WalletAppDisplayer
 import uk.gov.onelogin.features.FragmentActivityTestCase
 import uk.gov.onelogin.features.wallet.ui.WalletScreen
@@ -24,6 +25,7 @@ import uk.gov.onelogin.features.wallet.ui.WalletScreenViewModel
 class WalletScreenTest : FragmentActivityTestCase() {
     private val walletSdk: WalletSdk = mock()
     private val getWalletStoreId: GetWalletStoreId = mock()
+    private val loadingAnalyticsViewModel: LoadingScreenAnalyticsViewModel = mock()
     private val walletAppDisplayer: WalletAppDisplayer = {
         Text("Stub Wallet SDK")
     }
@@ -48,7 +50,8 @@ class WalletScreenTest : FragmentActivityTestCase() {
             WalletScreen(
                 false,
                 setDisplayContentAsFullScreen = { true },
-                viewModel = viewModel
+                viewModel = viewModel,
+                loadingAnalyticsViewModel = loadingAnalyticsViewModel,
             )
         }
 
@@ -56,6 +59,4 @@ class WalletScreenTest : FragmentActivityTestCase() {
             .onNodeWithText("Stub Wallet SDK")
             .assertIsDisplayed()
     }
-
-
 }

--- a/features/src/test/java/uk/gov/onelogin/features/unit/wallet/WalletScreenViewModelTest.kt
+++ b/features/src/test/java/uk/gov/onelogin/features/unit/wallet/WalletScreenViewModelTest.kt
@@ -1,16 +1,22 @@
 package uk.gov.onelogin.features.unit.wallet
 
 import app.cash.turbine.test
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.android.wallet.sdk.WalletSdk
+import uk.gov.logging.api.v3.Logger
 import uk.gov.onelogin.core.tokens.domain.retrieve.GetWalletStoreId
 import uk.gov.onelogin.core.ui.wallet.WalletAppDisplayerImpl
 import uk.gov.onelogin.features.extensions.CoroutinesTestExtension
@@ -98,6 +104,48 @@ class WalletScreenViewModelTest {
             "Wallet Store ID must not be null. This is guaranteed by ValidateWalletStoreId",
             cause.message,
         )
+    }
+
+    @Test
+    fun `given wallet store ID is null but coroutines are cancelled before retrieval, it does not crash`() {
+        val getWalletStoreIdCancelling = GetWalletStoreId {
+            currentCoroutineContext().cancel()
+            yield()
+            null
+        }
+        assertDoesNotThrow {
+            runTest {
+                WalletScreenViewModel(
+                    walletSdk = walletSdk,
+                    getWalletStoreId = getWalletStoreIdCancelling,
+                    walletAppDisplayer = walletAppDisplayer,
+                )
+            }
+        }
+    }
+
+    // This test is redundant once DCMAW-22143 is fixed.
+    @Test
+    fun `given wallet store ID is null because coroutine cancellation isn't propogated, it does not crash`() {
+        val getWalletStoreIdCancelling = GetWalletStoreId {
+            try {
+                currentCoroutineContext().cancel()
+                yield()
+            } catch (_: CancellationException) {
+                // Simulate the incorrect behaviour of Secure Store
+                // by consuming cancellation exceptions (DCMAW-22143).
+            }
+            null
+        }
+        assertDoesNotThrow {
+            runTest {
+                WalletScreenViewModel(
+                    walletSdk = walletSdk,
+                    getWalletStoreId = getWalletStoreIdCancelling,
+                    walletAppDisplayer = walletAppDisplayer,
+                )
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Context

Fixes a crash when attempting to add a wallet credential from a deep link from a cold start (DCMAW-22138).

The root cause, that Secure Store consumes coroutine cancellations and doesn't propagate them to calling code (DCMAW-22143), can be fixed separately.

## Evidence

[Screen_recording_20260818_163650.webm](https://github.com/user-attachments/assets/c15c1bca-afcb-4258-a8a3-679d897e414c)
