### PR TITLE
ci: Reduce number of Gradle workers / test shards from 2 to 1

### DIFF
--- a/config/actions/gradle-connected-test-managed/action.yml
+++ b/config/actions/gradle-connected-test-managed/action.yml
@@ -33,11 +33,11 @@ runs:
     - name: Run Gradle managed device test suites
       env:
         BUILD_DEBUG_APP_CHECK_TOKEN: ${{ inputs.app-check-token }}
-        INPUT_SHARD_COUNT: ${{ inputs.shard-count }}
         INPUT_VERSION_CODE: ${{ inputs.version-code }}
         INPUT_VERSION_NAME: ${{ inputs.version-name }}
         TOKEN: ${{ inputs.github-token }}
         USERNAME: ${{ inputs.github-actor }}
+        WORKER_COUNT: 1
       run: |
         ./.sh/tests/runInstrumentationChecks
       shell: bash


### PR DESCRIPTION
## Context

Tests that are sharded started to fail recently. This only happens in GitHub Actions and I'm not sure why. Reducing the worker count seems to stop the tests failing.

This doesn't seem to have an impact on the time spent running instrumentation tests (this PR takes 15 mins, a recent run on develop takes 16 mins).

## Example failures

- #1015 https://github.com/govuk-one-login/mobile-android-one-login-app/actions/runs/33050997026/job/98446248606
- #837 https://github.com/govuk-one-login/mobile-android-one-login-app/actions/runs/32961900638/job/98165437286