### PR TITLE
test: Update Android test device API level from 35 to 36

### DIFF
--- a/.sh/tests/runInstrumentationChecks
+++ b/.sh/tests/runInstrumentationChecks
@@ -29,7 +29,7 @@ then
     cleanManagedDevices
   echo "Running instrumentation checks without environment variables (local development)..."
   ./gradlew \
-    :app:aospAtdPixelXLApi35BuildDebugAndroidTest \
+    :app:aospAtdPixelXLApi36BuildDebugAndroidTest \
     --continue \
     --max-workers="${WORKER_COUNT}" \
     --stacktrace \
@@ -43,7 +43,7 @@ else
     -PversionName="${INPUT_VERSION_NAME}"
   echo "Running instrumentation checks with environment variables (GitHub workflow)..."
   ./gradlew \
-    :app:aospAtdPixelXLApi35BuildDebugAndroidTest \
+    :app:aospAtdPixelXLApi36BuildDebugAndroidTest \
     --continue \
     --stacktrace \
     -Pandroid.experimental.androidTest.numManagedDeviceShards="${WORKER_COUNT}" \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ val emulatorConfig: EmulatorConfig by extra(
         systemImageSources = setOf(
             SystemImageSource.AOSP_ATD
         ),
-        androidApiLevels = setOf(35),
+        androidApiLevels = setOf(36),
         deviceFilters = setOf("Pixel XL"),
     )
 )


### PR DESCRIPTION
## Context

See PR comment:
- https://github.com/govuk-one-login/mobile-android-one-login-app/pull/1015#discussion_r3913268849